### PR TITLE
Fixes deployment for web app github action

### DIFF
--- a/.github/workflows/main_forest-geo.yml
+++ b/.github/workflows/main_forest-geo.yml
@@ -10,11 +10,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-deploy:
+  build-and-deploy-webapp:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: webapp
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
 
     - name: Set up Node.js version
       uses: actions/setup-node@v1


### PR DESCRIPTION
This PR fixes addresses the following on our github actions config:

- Defines the name of the job to limit it to the web app deploy
- Sets up the working directory to webapp
- Renames the checkout branch from master to main