### PR TITLE
Change the title of the React app to ForestGEO

### DIFF
--- a/FrontEnd/public/index.html
+++ b/FrontEnd/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>ForestGEO</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "ForestGEO",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Closes #50 
To test: after you run the server, the title of the page in browser should be "ForestGEO".