### PR TITLE
github: Add frontend workflow for testing and builing on CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,62 @@
+name: Build and test Frontend
+
+on:
+  pull_request:
+    paths:
+    - 'FrontEnd/**'
+    - '.github/**'
+  push:
+    branches:
+      - main
+    paths:
+    - 'FrontEnd/**'
+    - '.github/**'
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        node-version: [16.x]
+
+    steps:
+    - uses: actions/checkout@v2.3.3
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install dependencies
+      run: |
+        pwd
+        cd FrontEnd
+        npm install
+
+    - name: Run linter
+      run: |
+        cd FrontEnd
+        npm run lint
+
+    - name: Run type checker
+      run: |
+        cd FrontEnd
+        npm run tsc
+
+    - name: Run tests
+      run: |
+        cd FrontEnd
+        npm test -- --passWithNoTests
+
+    - name: Build FrontEnd
+      run: |
+        cd FrontEnd
+        npm run build
+
+    - name: Build storybook
+      run: |
+        cd FrontEnd
+        npm run build-storybook

--- a/FrontEnd/.gitignore
+++ b/FrontEnd/.gitignore
@@ -23,3 +23,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .env
+
+# output from npm run build-storybook
+storybook-static
+

--- a/FrontEnd/README.md
+++ b/FrontEnd/README.md
@@ -45,6 +45,10 @@ Run the linter to find errors.
 
 Try and fix errors automatically.
 
+### `npm run tsc`
+
+Run the TypeScript type checker.
+
 ## Learn More
 
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).

--- a/FrontEnd/package.json
+++ b/FrontEnd/package.json
@@ -37,7 +37,8 @@
     "lint": "eslint src/**/*.{js,jsx,ts,tsx}",
     "lint-fix": "eslint src/**/*.{js,jsx,ts,tsx} --fix",
     "storybook": "start-storybook -p 6006 -s public",
-    "build-storybook": "build-storybook -s public"
+    "build-storybook": "build-storybook -s public",
+    "tsc": "tsc"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
So we have some Continue Integration. Every time we do a pull request for Frontend related things then the frontend checks are run, the frontend is built and the storybook is built. Hopefully catching errors for us!

We run on Windows and Ubuntu with the stable release of Node(16).

Adds a TypeScript type checking script "`npm run tsc`" to make sure things are type checked.

There's some docs for the matrix parts of the github workflow Actions here: https://docs.github.com/en/actions/learn-github-actions/contexts#example-usage-of-the-matrix-context