### PR TITLE
Implementing Dynamic Plot Selection

### DIFF
--- a/frontend/app/(login)/login/page.tsx
+++ b/frontend/app/(login)/login/page.tsx
@@ -6,6 +6,30 @@ import {animated, useTransition} from "@react-spring/web";
 import styles from "@/styles/styles.module.css";
 import Sidebar from "@/components/sidebar";
 import Box from "@mui/joy/Box";
+import {
+  useAttributeLoadDispatch,
+  useCensusLoadDispatch,
+  usePersonnelLoadDispatch,
+  usePlotsLoadDispatch,
+  useQuadratsLoadDispatch,
+  useSpeciesLoadDispatch,
+  useSubSpeciesLoadDispatch
+} from "@/app/contexts/fixeddatacontext";
+import {
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  LinearProgress,
+  Modal,
+  ModalDialog,
+  Stack,
+  Typography
+} from "@mui/joy";
+import WarningRoundedIcon from "@mui/icons-material/WarningRounded";
+import Divider from "@mui/joy/Divider";
+import {useFirstLoadContext, useFirstLoadDispatch} from "@/app/contexts/plotcontext";
+import EntryModal from "@/components/client/entrymodal";
 
 const slides = [
   'background-1.jpg',
@@ -29,9 +53,18 @@ export default function Page() {
     },
     exitBeforeEnter: true,
   })
-  useEffect(() => void setInterval(() => setIndex(state => (state + 1) % slides.length), 5000), [])
+  useEffect(
+    () => {
+      void setInterval(() => setIndex(state => (state + 1) % slides.length), 5000)
+    }, []);
   const {status} = useSession();
-  if (status == "authenticated") redirect('/dashboard');
+  if (status == "authenticated") {
+    return (
+      <>
+        <EntryModal />
+      </>
+    );
+  }
   else
     return (
       <>

--- a/frontend/app/(login)/login/page.tsx
+++ b/frontend/app/(login)/login/page.tsx
@@ -28,7 +28,7 @@ import {
 } from "@mui/joy";
 import WarningRoundedIcon from "@mui/icons-material/WarningRounded";
 import Divider from "@mui/joy/Divider";
-import {useFirstLoadContext, useFirstLoadDispatch} from "@/app/contexts/plotcontext";
+import {useFirstLoadContext, useFirstLoadDispatch} from "@/app/contexts/generalcontext";
 import EntryModal from "@/components/client/entrymodal";
 
 const slides = [

--- a/frontend/app/api/quadratsperplot/route.ts
+++ b/frontend/app/api/quadratsperplot/route.ts
@@ -1,0 +1,33 @@
+import {NextRequest, NextResponse} from "next/server";
+import sql from "mssql";
+import {sqlConfig} from "@/config/macros";
+import {AttributeRDS} from "@/config/sqlmacros";
+
+async function getSqlConnection(tries: number) {
+  return await sql.connect(sqlConfig).catch((err) => {
+    console.error(err);
+    if (tries == 5) {
+      throw new Error("Connection failure");
+    }
+    console.log("conn failed --> trying again!");
+    getSqlConnection(tries + 1);
+  });
+}
+
+async function runQuery(conn: sql.ConnectionPool, query: string) {
+  if (!conn) {
+    throw new Error("invalid ConnectionPool object. check connection string settings.")
+  }
+  return await conn.request().query(query);
+}
+export async function GET(request: NextRequest) {
+  let i = 0;
+  let conn = await getSqlConnection(i);
+  if (!conn) throw new Error('sql connection failed');
+  
+  let plotID = request.nextUrl.searchParams.get('plotID')!;
+  let results = await runQuery(conn, `SELECT COUNT(*) FROM forestgeo.Quadrats WHERE PlotID = ${plotID}`);
+  if (!results) throw new Error("call failed");
+  await conn.close();
+  return new NextResponse(JSON.stringify(Object.values(results.recordset[0])));
+}

--- a/frontend/app/contexts/generalcontext.tsx
+++ b/frontend/app/contexts/generalcontext.tsx
@@ -4,12 +4,12 @@ import {allCensus, allQuadrats, Plot, plots} from "@/config/macros";
 import PlotProvider, {PlotsContext} from "@/app/contexts/userselectioncontext";
 
 export const PlotListContext = createContext<Plot[] | null>(null);
-export const CensusContext = createContext<number | null>(null);
-export const QuadratContext = createContext<number | null>(null);
+export const QuadratListContext = createContext<number[] | null>(null);
+export const CensusListContext = createContext<number[] | null>(null);
 export const FirstLoadContext = createContext<boolean | null>(null);
 export const PlotListDispatchContext = createContext<Dispatch<{ plotList: Plot[] | null }> | null>(null);
-export const CensusDispatchContext = createContext<Dispatch<{ census: number | null }> | null>(null);
-export const QuadratDispatchContext = createContext<Dispatch<{ quadrat: number | null }> | null>(null);
+export const QuadratListDispatchContext = createContext<Dispatch<{ quadratList: number[] | null }> | null>(null);
+export const CensusListDispatchContext = createContext<Dispatch<{ censusList: number[] | null }> | null>(null);
 export const FirstLoadDispatchContext = createContext<Dispatch<{ firstLoad: boolean }> | null>(null);
 
 export function ContextsProvider({children}: { children: React.ReactNode }) {
@@ -17,14 +17,17 @@ export function ContextsProvider({children}: { children: React.ReactNode }) {
     plotListReducer,
     plots
   )
-  const [census, censusDispatch] = useReducer(
-    censusReducer,
-    null
-  );
-  const [quadrat, quadratDispatch] = useReducer(
-    quadratReducer,
-    null
+  
+  const [quadratList, quadratListDispatch] = useReducer(
+    quadratListReducer,
+    []
   )
+  
+  const [censusList, censusListDispatch] = useReducer(
+    censusListReducer,
+    []
+  )
+  
   const [firstLoad, firstLoadDispatch] = useReducer(
     firstLoadReducer,
     true
@@ -35,37 +38,25 @@ export function ContextsProvider({children}: { children: React.ReactNode }) {
     <>
       <PlotListContext.Provider value={plotList}>
         <PlotListDispatchContext.Provider value={plotListDispatch}>
-          <PlotProvider>
-            <CensusContext.Provider value={census}>
-              <CensusDispatchContext.Provider value={censusDispatch}>
-                <QuadratContext.Provider value={quadrat}>
-                  <QuadratDispatchContext.Provider value={quadratDispatch}>
-                    <FirstLoadContext.Provider value={firstLoad}>
-                      <FirstLoadDispatchContext.Provider value={firstLoadDispatch}>
+          <QuadratListContext.Provider value={quadratList}>
+            <QuadratListDispatchContext.Provider value={quadratListDispatch}>
+              <CensusListContext.Provider value={censusList}>
+                <CensusListDispatchContext.Provider value={censusListDispatch}>
+                  <FirstLoadContext.Provider value={firstLoad}>
+                    <FirstLoadDispatchContext.Provider value={firstLoadDispatch}>
+                      <PlotProvider>
                         {children}
-                      </FirstLoadDispatchContext.Provider>
-                    </FirstLoadContext.Provider>
-                  </QuadratDispatchContext.Provider>
-                </QuadratContext.Provider>
-              </CensusDispatchContext.Provider>
-            </CensusContext.Provider>
-          </PlotProvider>
+                      </PlotProvider>
+                    </FirstLoadDispatchContext.Provider>
+                  </FirstLoadContext.Provider>
+                </CensusListDispatchContext.Provider>
+              </CensusListContext.Provider>
+            </QuadratListDispatchContext.Provider>
+          </QuadratListContext.Provider>
         </PlotListDispatchContext.Provider>
       </PlotListContext.Provider>
     </>
   );
-}
-
-function censusReducer(currentCensus: any, action: { census: number | null }) {
-  if (action.census == null) return null;
-  else if (allCensus.includes(action.census)) return action.census;
-  else return currentCensus;
-}
-
-function quadratReducer(currentQuadrat: any, action: { quadrat: number | null }) {
-  if (action.quadrat == null) return null;
-  else if (allQuadrats.includes(action.quadrat)) return action.quadrat;
-  else return currentQuadrat;
 }
 
 function firstLoadReducer(currentState: any, action: { firstLoad: boolean | null }) {
@@ -76,21 +67,11 @@ function firstLoadReducer(currentState: any, action: { firstLoad: boolean | null
 function plotListReducer(_currentPlotList: any, action: {plotList: Plot[] | null}) {
   return action.plotList;
 }
-
-export function useCensusContext() {
-  return useContext(CensusContext);
+function quadratListReducer(_currentQuadratList: any, action: { quadratList: number[] | null}) {
+  return action.quadratList;
 }
-
-export function useCensusDispatch() {
-  return useContext(CensusDispatchContext);
-}
-
-export function useQuadratContext() {
-  return useContext(QuadratContext);
-}
-
-export function useQuadratDispatch() {
-  return useContext(QuadratDispatchContext);
+function censusListReducer(_currentCensusList: any, action: { censusList: number[] | null}) {
+  return action.censusList;
 }
 
 export function useFirstLoadContext() {

--- a/frontend/app/contexts/generalcontext.tsx
+++ b/frontend/app/contexts/generalcontext.tsx
@@ -1,14 +1,13 @@
 "use client";
 import React, {createContext, Dispatch, useContext, useReducer} from 'react';
 import {allCensus, allQuadrats, Plot, plots} from "@/config/macros";
+import PlotProvider, {PlotsContext} from "@/app/contexts/userselectioncontext";
 
 export const PlotListContext = createContext<Plot[] | null>(null);
-export const PlotsContext = createContext<Plot | null>(null);
 export const CensusContext = createContext<number | null>(null);
 export const QuadratContext = createContext<number | null>(null);
 export const FirstLoadContext = createContext<boolean | null>(null);
 export const PlotListDispatchContext = createContext<Dispatch<{ plotList: Plot[] | null }> | null>(null);
-export const PlotsDispatchContext = createContext<Dispatch<{ plotKey: string | null }> | null>(null);
 export const CensusDispatchContext = createContext<Dispatch<{ census: number | null }> | null>(null);
 export const QuadratDispatchContext = createContext<Dispatch<{ quadrat: number | null }> | null>(null);
 export const FirstLoadDispatchContext = createContext<Dispatch<{ firstLoad: boolean }> | null>(null);
@@ -18,10 +17,6 @@ export function ContextsProvider({children}: { children: React.ReactNode }) {
     plotListReducer,
     plots
   )
-  const [plot, plotDispatch] = useReducer(
-    plotsReducer,
-    null
-  );
   const [census, censusDispatch] = useReducer(
     censusReducer,
     null
@@ -40,40 +35,25 @@ export function ContextsProvider({children}: { children: React.ReactNode }) {
     <>
       <PlotListContext.Provider value={plotList}>
         <PlotListDispatchContext.Provider value={plotListDispatch}>
-          <PlotsContext.Provider value={plot}>
-            <PlotsDispatchContext.Provider value={plotDispatch}>
-              <CensusContext.Provider value={census}>
-                <CensusDispatchContext.Provider value={censusDispatch}>
-                  <QuadratContext.Provider value={quadrat}>
-                    <QuadratDispatchContext.Provider value={quadratDispatch}>
-                      <FirstLoadContext.Provider value={firstLoad}>
-                        <FirstLoadDispatchContext.Provider value={firstLoadDispatch}>
-                          {children}
-                        </FirstLoadDispatchContext.Provider>
-                      </FirstLoadContext.Provider>
-                    </QuadratDispatchContext.Provider>
-                  </QuadratContext.Provider>
-                </CensusDispatchContext.Provider>
-              </CensusContext.Provider>
-            </PlotsDispatchContext.Provider>
-          </PlotsContext.Provider>
+          <PlotProvider>
+            <CensusContext.Provider value={census}>
+              <CensusDispatchContext.Provider value={censusDispatch}>
+                <QuadratContext.Provider value={quadrat}>
+                  <QuadratDispatchContext.Provider value={quadratDispatch}>
+                    <FirstLoadContext.Provider value={firstLoad}>
+                      <FirstLoadDispatchContext.Provider value={firstLoadDispatch}>
+                        {children}
+                      </FirstLoadDispatchContext.Provider>
+                    </FirstLoadContext.Provider>
+                  </QuadratDispatchContext.Provider>
+                </QuadratContext.Provider>
+              </CensusDispatchContext.Provider>
+            </CensusContext.Provider>
+          </PlotProvider>
         </PlotListDispatchContext.Provider>
       </PlotListContext.Provider>
     </>
   );
-}
-
-function plotsReducer(currentPlot: any, action: { plotKey: string | null }) {
-  const plotListContext = usePlotListContext();
-  if (plotListContext) {
-    if (action.plotKey == null) return null;
-    else if (plotListContext.find((p) => p.key == action.plotKey)) return plotListContext.find((p) => p.key == action.plotKey);
-    else return currentPlot;
-  } else {
-    if (action.plotKey == null) return null;
-    else if (plots.find((p) => p.key == action.plotKey)) return plots.find((p) => p.key == action.plotKey);
-    else return currentPlot;
-  }
 }
 
 function censusReducer(currentCensus: any, action: { census: number | null }) {
@@ -95,14 +75,6 @@ function firstLoadReducer(currentState: any, action: { firstLoad: boolean | null
 
 function plotListReducer(_currentPlotList: any, action: {plotList: Plot[] | null}) {
   return action.plotList;
-}
-
-export function usePlotContext() {
-  return useContext(PlotsContext);
-}
-
-export function usePlotDispatch() {
-  return useContext(PlotsDispatchContext);
 }
 
 export function useCensusContext() {

--- a/frontend/app/contexts/generalcontext.tsx
+++ b/frontend/app/contexts/generalcontext.tsx
@@ -63,7 +63,6 @@ function firstLoadReducer(currentState: any, action: { firstLoad: boolean | null
   if (action.firstLoad == false && currentState) return action.firstLoad;
   else return currentState;
 }
-
 function plotListReducer(_currentPlotList: any, action: {plotList: Plot[] | null}) {
   return action.plotList;
 }
@@ -73,19 +72,27 @@ function quadratListReducer(_currentQuadratList: any, action: { quadratList: num
 function censusListReducer(_currentCensusList: any, action: { censusList: number[] | null}) {
   return action.censusList;
 }
-
 export function useFirstLoadContext() {
   return useContext(FirstLoadContext);
 }
-
 export function useFirstLoadDispatch() {
   return useContext(FirstLoadDispatchContext);
 }
-
 export function usePlotListContext() {
   return useContext(PlotListContext);
 }
-
 export function usePlotListDispatch() {
   return useContext(PlotListDispatchContext);
+}
+export function useQuadratListContext() {
+  return useContext(QuadratListContext);
+}
+export function useQuadratListDispatch() {
+  return useContext(QuadratListDispatchContext);
+}
+export function useCensusListContext() {
+  return useContext(CensusListContext);
+}
+export function useCensusListDispatch() {
+  return useContext(CensusListDispatchContext);
 }

--- a/frontend/app/contexts/plotcontext.tsx
+++ b/frontend/app/contexts/plotcontext.tsx
@@ -2,16 +2,22 @@
 import React, {createContext, Dispatch, useContext, useReducer} from 'react';
 import {allCensus, allQuadrats, Plot, plots} from "@/config/macros";
 
+export const PlotListContext = createContext<Plot[] | null>(null);
 export const PlotsContext = createContext<Plot | null>(null);
 export const CensusContext = createContext<number | null>(null);
 export const QuadratContext = createContext<number | null>(null);
 export const FirstLoadContext = createContext<boolean | null>(null);
+export const PlotListDispatchContext = createContext<Dispatch<{ plotList: Plot[] | null }> | null>(null);
 export const PlotsDispatchContext = createContext<Dispatch<{ plotKey: string | null }> | null>(null);
 export const CensusDispatchContext = createContext<Dispatch<{ census: number | null }> | null>(null);
 export const QuadratDispatchContext = createContext<Dispatch<{ quadrat: number | null }> | null>(null);
 export const FirstLoadDispatchContext = createContext<Dispatch<{ firstLoad: boolean }> | null>(null);
 
 export function ContextsProvider({children}: { children: React.ReactNode }) {
+  const [plotList, plotListDispatch] = useReducer(
+    plotListReducer,
+    plots
+  )
   const [plot, plotDispatch] = useReducer(
     plotsReducer,
     null
@@ -29,31 +35,45 @@ export function ContextsProvider({children}: { children: React.ReactNode }) {
     true
   )
   
+  
   return (
-    <PlotsContext.Provider value={plot}>
-      <PlotsDispatchContext.Provider value={plotDispatch}>
-        <CensusContext.Provider value={census}>
-          <CensusDispatchContext.Provider value={censusDispatch}>
-            <QuadratContext.Provider value={quadrat}>
-              <QuadratDispatchContext.Provider value={quadratDispatch}>
-                <FirstLoadContext.Provider value={firstLoad}>
-                  <FirstLoadDispatchContext.Provider value={firstLoadDispatch}>
-                    {children}
-                  </FirstLoadDispatchContext.Provider>
-                </FirstLoadContext.Provider>
-              </QuadratDispatchContext.Provider>
-            </QuadratContext.Provider>
-          </CensusDispatchContext.Provider>
-        </CensusContext.Provider>
-      </PlotsDispatchContext.Provider>
-    </PlotsContext.Provider>
+    <>
+      <PlotListContext.Provider value={plotList}>
+        <PlotListDispatchContext.Provider value={plotListDispatch}>
+          <PlotsContext.Provider value={plot}>
+            <PlotsDispatchContext.Provider value={plotDispatch}>
+              <CensusContext.Provider value={census}>
+                <CensusDispatchContext.Provider value={censusDispatch}>
+                  <QuadratContext.Provider value={quadrat}>
+                    <QuadratDispatchContext.Provider value={quadratDispatch}>
+                      <FirstLoadContext.Provider value={firstLoad}>
+                        <FirstLoadDispatchContext.Provider value={firstLoadDispatch}>
+                          {children}
+                        </FirstLoadDispatchContext.Provider>
+                      </FirstLoadContext.Provider>
+                    </QuadratDispatchContext.Provider>
+                  </QuadratContext.Provider>
+                </CensusDispatchContext.Provider>
+              </CensusContext.Provider>
+            </PlotsDispatchContext.Provider>
+          </PlotsContext.Provider>
+        </PlotListDispatchContext.Provider>
+      </PlotListContext.Provider>
+    </>
   );
 }
 
 function plotsReducer(currentPlot: any, action: { plotKey: string | null }) {
-  if (action.plotKey == null) return null;
-  else if (plots.find((p) => p.key == action.plotKey)) return plots.find((p) => p.key == action.plotKey);
-  else return currentPlot;
+  const plotListContext = usePlotListContext();
+  if (plotListContext) {
+    if (action.plotKey == null) return null;
+    else if (plotListContext.find((p) => p.key == action.plotKey)) return plotListContext.find((p) => p.key == action.plotKey);
+    else return currentPlot;
+  } else {
+    if (action.plotKey == null) return null;
+    else if (plots.find((p) => p.key == action.plotKey)) return plots.find((p) => p.key == action.plotKey);
+    else return currentPlot;
+  }
 }
 
 function censusReducer(currentCensus: any, action: { census: number | null }) {
@@ -71,6 +91,10 @@ function quadratReducer(currentQuadrat: any, action: { quadrat: number | null })
 function firstLoadReducer(currentState: any, action: { firstLoad: boolean | null }) {
   if (action.firstLoad == false && currentState) return action.firstLoad;
   else return currentState;
+}
+
+function plotListReducer(_currentPlotList: any, action: {plotList: Plot[] | null}) {
+  return action.plotList;
 }
 
 export function usePlotContext() {
@@ -103,4 +127,12 @@ export function useFirstLoadContext() {
 
 export function useFirstLoadDispatch() {
   return useContext(FirstLoadDispatchContext);
+}
+
+export function usePlotListContext() {
+  return useContext(PlotListContext);
+}
+
+export function usePlotListDispatch() {
+  return useContext(PlotListDispatchContext);
 }

--- a/frontend/app/contexts/userselectioncontext.tsx
+++ b/frontend/app/contexts/userselectioncontext.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, {createContext, Dispatch, useContext, useReducer} from "react";
 import {allCensus, allQuadrats, Plot, plots} from "@/config/macros";
-import {usePlotListContext} from "@/app/contexts/generalcontext";
+import {useCensusListContext, usePlotListContext, useQuadratListContext} from "@/app/contexts/generalcontext";
 
 export const PlotsContext = createContext<Plot | null>(null);
 export const CensusContext = createContext<number | null>(null);
@@ -55,15 +55,29 @@ function plotsReducer(currentPlot: any, action: { plotKey: string | null }) {
   }
 }
 function censusReducer(currentCensus: any, action: { census: number | null }) {
-  if (action.census == null) return null;
-  else if (allCensus.includes(action.census)) return action.census;
-  else return currentCensus;
+  let censusListContext = useCensusListContext();
+  if (censusListContext) {
+    if (action.census == null) return null;
+    else if (censusListContext.includes(action.census)) return action.census;
+    else return currentCensus;
+  } else {
+    if (action.census == null) return null;
+    else if (allCensus.includes(action.census)) return action.census;
+    else return currentCensus;
+  }
 }
 
 function quadratReducer(currentQuadrat: any, action: { quadrat: number | null }) {
-  if (action.quadrat == null) return null;
-  else if (allQuadrats.includes(action.quadrat)) return action.quadrat;
-  else return currentQuadrat;
+  let quadratListContext = useQuadratListContext();
+  if (quadratListContext) {
+    if (action.quadrat == null) return null;
+    else if (quadratListContext.includes(action.quadrat)) return action.quadrat;
+    else return currentQuadrat;
+  } else {
+    if (action.quadrat == null) return null;
+    else if (allQuadrats.includes(action.quadrat)) return action.quadrat;
+    else return currentQuadrat;
+  }
 }
 
 export function usePlotContext() {

--- a/frontend/app/contexts/userselectioncontext.tsx
+++ b/frontend/app/contexts/userselectioncontext.tsx
@@ -1,21 +1,41 @@
 "use client";
 import React, {createContext, Dispatch, useContext, useReducer} from "react";
-import {Plot, plots} from "@/config/macros";
+import {allCensus, allQuadrats, Plot, plots} from "@/config/macros";
 import {usePlotListContext} from "@/app/contexts/generalcontext";
 
 export const PlotsContext = createContext<Plot | null>(null);
+export const CensusContext = createContext<number | null>(null);
+export const QuadratContext = createContext<number | null>(null);
 export const PlotsDispatchContext = createContext<Dispatch<{ plotKey: string | null }> | null>(null);
+export const CensusDispatchContext = createContext<Dispatch<{ census: number | null }> | null>(null);
+export const QuadratDispatchContext = createContext<Dispatch<{ quadrat: number | null }> | null>(null);
 
 export default function PlotProvider({children}: { children: React.ReactNode }) {
   const [plot, plotDispatch] = useReducer(
     plotsReducer,
     null
   );
+  const [census, censusDispatch] = useReducer(
+    censusReducer,
+    null
+  );
+  const [quadrat, quadratDispatch] = useReducer(
+    quadratReducer,
+    null
+  );
   return (
     <>
       <PlotsContext.Provider value={plot}>
         <PlotsDispatchContext.Provider value={plotDispatch}>
-          {children}
+          <CensusContext.Provider value={census}>
+            <CensusDispatchContext.Provider value={censusDispatch}>
+              <QuadratContext.Provider value={quadrat}>
+                <QuadratDispatchContext.Provider value={quadratDispatch}>
+                  {children}
+                </QuadratDispatchContext.Provider>
+              </QuadratContext.Provider>
+            </CensusDispatchContext.Provider>
+          </CensusContext.Provider>
         </PlotsDispatchContext.Provider>
       </PlotsContext.Provider>
     </>
@@ -34,6 +54,17 @@ function plotsReducer(currentPlot: any, action: { plotKey: string | null }) {
     else return currentPlot;
   }
 }
+function censusReducer(currentCensus: any, action: { census: number | null }) {
+  if (action.census == null) return null;
+  else if (allCensus.includes(action.census)) return action.census;
+  else return currentCensus;
+}
+
+function quadratReducer(currentQuadrat: any, action: { quadrat: number | null }) {
+  if (action.quadrat == null) return null;
+  else if (allQuadrats.includes(action.quadrat)) return action.quadrat;
+  else return currentQuadrat;
+}
 
 export function usePlotContext() {
   return useContext(PlotsContext);
@@ -41,4 +72,19 @@ export function usePlotContext() {
 
 export function usePlotDispatch() {
   return useContext(PlotsDispatchContext);
+}
+export function useCensusContext() {
+  return useContext(CensusContext);
+}
+
+export function useCensusDispatch() {
+  return useContext(CensusDispatchContext);
+}
+
+export function useQuadratContext() {
+  return useContext(QuadratContext);
+}
+
+export function useQuadratDispatch() {
+  return useContext(QuadratDispatchContext);
 }

--- a/frontend/app/contexts/userselectioncontext.tsx
+++ b/frontend/app/contexts/userselectioncontext.tsx
@@ -1,0 +1,44 @@
+"use client";
+import React, {createContext, Dispatch, useContext, useReducer} from "react";
+import {Plot, plots} from "@/config/macros";
+import {usePlotListContext} from "@/app/contexts/generalcontext";
+
+export const PlotsContext = createContext<Plot | null>(null);
+export const PlotsDispatchContext = createContext<Dispatch<{ plotKey: string | null }> | null>(null);
+
+export default function PlotProvider({children}: { children: React.ReactNode }) {
+  const [plot, plotDispatch] = useReducer(
+    plotsReducer,
+    null
+  );
+  return (
+    <>
+      <PlotsContext.Provider value={plot}>
+        <PlotsDispatchContext.Provider value={plotDispatch}>
+          {children}
+        </PlotsDispatchContext.Provider>
+      </PlotsContext.Provider>
+    </>
+  );
+}
+
+function plotsReducer(currentPlot: any, action: { plotKey: string | null }) {
+  let plotListContext = usePlotListContext();
+  if (plotListContext) {
+    if (action.plotKey == null) return null;
+    else if (plotListContext.find((p) => p.key == action.plotKey)) return plotListContext.find((p) => p.key == action.plotKey);
+    else return currentPlot;
+  } else {
+    if (action.plotKey == null) return null;
+    else if (plots.find((p) => p.key == action.plotKey)) return plots.find((p) => p.key == action.plotKey);
+    else return currentPlot;
+  }
+}
+
+export function usePlotContext() {
+  return useContext(PlotsContext);
+}
+
+export function usePlotDispatch() {
+  return useContext(PlotsDispatchContext);
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,7 +1,7 @@
 import "@/styles/globals.css";
 import {Providers} from "./providers";
 import React from "react";
-import {ContextsProvider} from "@/app/contexts/plotcontext";
+import {ContextsProvider} from "@/app/contexts/generalcontext";
 import {Box} from "@mui/joy";
 import {FixedDataProvider} from "./contexts/fixeddatacontext";
 

--- a/frontend/components/client/endpoint.tsx
+++ b/frontend/components/client/endpoint.tsx
@@ -32,65 +32,6 @@ import {useFirstLoadContext, useFirstLoadDispatch} from "@/app/contexts/plotcont
 import WarningRoundedIcon from "@mui/icons-material/WarningRounded";
 
 export default function Endpoint({children,}: { children: React.ReactNode }) {
-  const [loading, setLoading] = useState(0);
-  const [loadingMsg, setLoadingMsg] = useState('');
-  const attributeLoadDispatch = useAttributeLoadDispatch();
-  const censusLoadDispatch = useCensusLoadDispatch();
-  const personnelLoadDispatch = usePersonnelLoadDispatch();
-  const quadratsLoadDispatch = useQuadratsLoadDispatch();
-  const speciesLoadDispatch = useSpeciesLoadDispatch();
-  const plotsLoadDispatch = usePlotsLoadDispatch();
-  useEffect(() => {
-    const fetchData = async () => {
-      setLoading(0);
-      setLoadingMsg('Retrieving Attributes...');
-      let response = await fetch(`/api/fixeddata/attributes`, {method: 'GET'});
-      setLoading(9);
-      if (attributeLoadDispatch) {
-        attributeLoadDispatch({attributeLoad: await response.json()});
-      }
-      setLoading(18);
-      setLoadingMsg('Retrieving Census...');
-      response = await fetch(`/api/fixeddata/census`, {method: 'GET'});
-      setLoading(27);
-      if (censusLoadDispatch) {
-        censusLoadDispatch({censusLoad: await response.json()});
-      }
-      setLoading(36);
-      setLoadingMsg('Retrieving Personnel...');
-      await new Promise(f => setTimeout(f, 1000));
-      // response = await fetch(`/api/fixeddata/personnel`, {method: 'GET'});
-      setLoading(45);
-      // if(personnelLoadDispatch){
-      //   personnelLoadDispatch({personnelLoad: await response.json()});
-      // }
-      setLoading(54);
-      setLoadingMsg('Retrieving Quadrats...');
-      await new Promise(f => setTimeout(f, 1000));
-      // response = await fetch(`/api/fixeddata/quadrats`, {method: 'GET'});
-      setLoading(63);
-      // if (quadratsLoadDispatch) {
-      //   quadratsLoadDispatch({quadratsLoad: await response.json()});
-      // }
-      setLoading(72);
-      setLoadingMsg('Retrieving Species...');
-      await new Promise(f => setTimeout(f, 1000));
-      // response = await fetch(`/api/fixeddata/species`, {method: 'GET'});
-      setLoading(81);
-      // if (speciesLoadDispatch) {
-      //   speciesLoadDispatch({speciesLoad: await response.json()});
-      // }
-      setLoading(90)
-      setLoadingMsg('Retrieving Plots...')
-      response = await fetch(`/api/fixeddata/plots`, {method: 'GET'});
-      setLoading(99);
-      if (plotsLoadDispatch) {
-        plotsLoadDispatch({plotsLoad: await response.json()});
-      }
-      setLoading(100);
-    }
-    fetchData().catch(console.error);
-  }, []);
   useSession({
     required: true,
     onUnauthenticated() {
@@ -133,8 +74,6 @@ export default function Endpoint({children,}: { children: React.ReactNode }) {
   }
   
   let pathname = usePathname();
-  const firstLoad = useFirstLoadContext();
-  const firstLoadDispatch = useFirstLoadDispatch();
   return (
     <>
       <Sidebar/>
@@ -173,41 +112,7 @@ export default function Endpoint({children,}: { children: React.ReactNode }) {
             flexDirection: 'column',
             paddingLeft: 2
           }}>
-          {firstLoad ? <Modal open={firstLoad}
-                              sx={{display: 'flex', flex: 1}}
-                              onClose={(_event: React.MouseEvent<HTMLButtonElement>, reason: string) => {
-                                if (reason !== 'backdropClick' && reason !== 'escapeKeyDown') {
-                                  firstLoadDispatch ? firstLoadDispatch({firstLoad: false}) : null
-                                }
-                              }}>
-            <ModalDialog variant="outlined" role="alertdialog">
-              <DialogTitle>
-                <WarningRoundedIcon/>
-                <Typography level={"title-lg"}>Welcome to the Application!</Typography>
-              </DialogTitle>
-              <Divider/>
-              <DialogContent>
-                <Stack direction={"column"} sx={{display: 'flex', flex: 1}}>
-                  {loading != 100 ?
-                    <>
-                      <LinearProgress sx={{display: 'flex', flex: 1}} determinate size={"lg"} value={loading}/>
-                      <Typography level="body-sm" color="neutral"><b>{loadingMsg}</b></Typography>
-                    </> :
-                    <>
-                      <Typography level={"body-sm"} >Select <b>Core Measurements Hub</b> to view existing core measurement data for a given plot, census, and quadrat</Typography>
-                      <Typography level={"body-sm"}>Select <b>CSV & ArcGIS File Upload Hub</b> to upload core measurements in either CSV format or in collected ArcGIS format</Typography>
-                      <Typography level={"body-sm"}>Select <b>Measurement Properties Hub</b> to view and edit measurement properties used in data collection</Typography>
-                    </>}
-                </Stack>
-              </DialogContent>
-              <DialogActions>
-                <Button variant="plain" color="neutral" disabled={loading != 100}
-                        onClick={() => firstLoadDispatch ? firstLoadDispatch({firstLoad: false}) : null}>
-                  Continue
-                </Button>
-              </DialogActions>
-            </ModalDialog>
-          </Modal> : children}
+          {children}
         </Box>
         <Divider orientation={"horizontal"}/>
         <Box mt={3}

--- a/frontend/components/client/endpoint.tsx
+++ b/frontend/components/client/endpoint.tsx
@@ -28,7 +28,7 @@ import {
   useQuadratsLoadDispatch,
   useSpeciesLoadDispatch
 } from "@/app/contexts/fixeddatacontext";
-import {useFirstLoadContext, useFirstLoadDispatch} from "@/app/contexts/plotcontext";
+import {useFirstLoadContext, useFirstLoadDispatch} from "@/app/contexts/generalcontext";
 import WarningRoundedIcon from "@mui/icons-material/WarningRounded";
 
 export default function Endpoint({children,}: { children: React.ReactNode }) {

--- a/frontend/components/client/entrymodal.tsx
+++ b/frontend/components/client/entrymodal.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import React, {useEffect, useState} from "react";
+import {
+  useAttributeLoadDispatch,
+  useCensusLoadDispatch,
+  usePersonnelLoadDispatch,
+  usePlotsLoadDispatch,
+  useQuadratsLoadDispatch,
+  useSpeciesLoadDispatch,
+  useSubSpeciesLoadDispatch
+} from "@/app/contexts/fixeddatacontext";
+import {useFirstLoadContext, useFirstLoadDispatch} from "@/app/contexts/plotcontext";
+import {
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  LinearProgress,
+  Modal,
+  ModalDialog,
+  Stack,
+  Typography
+} from "@mui/joy";
+import WarningRoundedIcon from "@mui/icons-material/WarningRounded";
+import Divider from "@mui/joy/Divider";
+import {redirect} from "next/navigation";
+
+export default function EntryModal() {
+  const [loading, setLoading] = useState(0);
+  const [loadingMsg, setLoadingMsg] = useState('');
+  const attributeLoadDispatch = useAttributeLoadDispatch();
+  const censusLoadDispatch = useCensusLoadDispatch();
+  const personnelLoadDispatch = usePersonnelLoadDispatch();
+  const quadratsLoadDispatch = useQuadratsLoadDispatch();
+  const speciesLoadDispatch = useSpeciesLoadDispatch();
+  const subSpeciesLoadDispatch = useSubSpeciesLoadDispatch();
+  const plotsLoadDispatch = usePlotsLoadDispatch();
+  const firstLoad = useFirstLoadContext();
+  const firstLoadDispatch = useFirstLoadDispatch();
+  const interval = 100 / 14;
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(loading + interval);
+      setLoadingMsg('Retrieving Attributes...');
+      let response = await fetch(`/api/fixeddata/attributes`, {method: 'GET'});
+      setLoading(loading + interval);
+      if (attributeLoadDispatch) {
+        attributeLoadDispatch({attributeLoad: await response.json()});
+      }
+      setLoading(loading + interval);
+      setLoadingMsg('Retrieving Census...');
+      response = await fetch(`/api/fixeddata/census`, {method: 'GET'});
+      setLoading(loading + interval);
+      if (censusLoadDispatch) {
+        censusLoadDispatch({censusLoad: await response.json()});
+      }
+      setLoading(loading + interval);
+      setLoadingMsg('Retrieving Personnel...');
+      response = await fetch(`/api/fixeddata/personnel`, {method: 'GET'});
+      setLoading(loading + interval);
+      if(personnelLoadDispatch){
+        personnelLoadDispatch({personnelLoad: await response.json()});
+      }
+      setLoading(loading + interval);
+      setLoadingMsg('Retrieving Quadrats...');
+      response = await fetch(`/api/fixeddata/quadrats`, {method: 'GET'});
+      setLoading(loading + interval);
+      if (quadratsLoadDispatch) {
+        quadratsLoadDispatch({quadratsLoad: await response.json()});
+      }
+      setLoading(loading + interval);
+      setLoadingMsg('Retrieving Species...');
+      response = await fetch(`/api/fixeddata/species`, {method: 'GET'});
+      setLoading(loading + interval);
+      if (speciesLoadDispatch) {
+        speciesLoadDispatch({speciesLoad: await response.json()});
+      }
+      setLoading(loading + interval);
+      setLoadingMsg('Retrieving SubSpecies...');
+      response = await fetch(`/api/fixeddata/subspecies`, {method: 'GET'});
+      setLoading(loading + interval);
+      if (subSpeciesLoadDispatch) {
+        subSpeciesLoadDispatch({subSpeciesLoad: await response.json()});
+      }
+      setLoading(loading + interval)
+      setLoadingMsg('Retrieving Plots...')
+      response = await fetch(`/api/fixeddata/plots`, {method: 'GET'});
+      setLoading(loading + interval);
+      if (plotsLoadDispatch) {
+        plotsLoadDispatch({plotsLoad: await response.json()});
+      }
+      setLoading(100);
+    }
+    fetchData().catch(console.error);
+  }, []);
+  
+  return (
+    <>
+      {firstLoad ? <Modal open={firstLoad}
+                          sx={{display: 'flex', flex: 1}}
+                          onClose={(_event: React.MouseEvent<HTMLButtonElement>, reason: string) => {
+                            if (reason !== 'backdropClick' && reason !== 'escapeKeyDown') {
+                              firstLoadDispatch ? firstLoadDispatch({firstLoad: false}) : null
+                            }
+                          }}>
+        <ModalDialog variant="outlined" role="alertdialog">
+          <DialogTitle>
+            <WarningRoundedIcon/>
+            <Typography level={"title-lg"}>Welcome to the Application!</Typography>
+          </DialogTitle>
+          <Divider/>
+          <DialogContent>
+            <Stack direction={"column"} sx={{display: 'flex', flex: 1}}>
+              {loading != 100 ?
+                <>
+                  <LinearProgress sx={{display: 'flex', flex: 1}} determinate size={"lg"} value={loading}/>
+                  <Typography level="body-sm" color="neutral"><b>{loadingMsg}</b></Typography>
+                </> :
+                <>
+                  <Typography level={"body-sm"}>Select <b>Core Measurements Hub</b> to view existing core
+                    measurement data for a given plot, census, and quadrat</Typography>
+                  <Typography level={"body-sm"}>Select <b>CSV & ArcGIS File Upload Hub</b> to upload core
+                    measurements in either CSV format or in collected ArcGIS format</Typography>
+                  <Typography level={"body-sm"}>Select <b>Measurement Properties Hub</b> to view and edit
+                    measurement properties used in data collection</Typography>
+                </>}
+            </Stack>
+          </DialogContent>
+          <DialogActions>
+            <Button variant="plain" color="neutral" disabled={loading != 100}
+                    onClick={() => firstLoadDispatch ? firstLoadDispatch({firstLoad: false}) : null}>
+              Continue
+            </Button>
+          </DialogActions>
+        </ModalDialog>
+      </Modal> : redirect('/dashboard')}
+    </>
+  );
+}

--- a/frontend/components/client/entrymodal.tsx
+++ b/frontend/components/client/entrymodal.tsx
@@ -10,7 +10,7 @@ import {
   useSpeciesLoadDispatch,
   useSubSpeciesLoadDispatch
 } from "@/app/contexts/fixeddatacontext";
-import {useFirstLoadContext, useFirstLoadDispatch} from "@/app/contexts/plotcontext";
+import {useFirstLoadContext, useFirstLoadDispatch, usePlotListDispatch} from "@/app/contexts/generalcontext";
 import {
   Button,
   DialogActions,
@@ -25,6 +25,9 @@ import {
 import WarningRoundedIcon from "@mui/icons-material/WarningRounded";
 import Divider from "@mui/joy/Divider";
 import {redirect} from "next/navigation";
+import {Plot} from "@/config/macros";
+import {QuadratRDS} from "@/config/sqlmacros";
+import {GridValidRowModel} from "@mui/x-data-grid";
 
 export default function EntryModal() {
   const [loading, setLoading] = useState(0);
@@ -36,6 +39,7 @@ export default function EntryModal() {
   const speciesLoadDispatch = useSpeciesLoadDispatch();
   const subSpeciesLoadDispatch = useSubSpeciesLoadDispatch();
   const plotsLoadDispatch = usePlotsLoadDispatch();
+  const plotsListDispatch = usePlotListDispatch();
   const firstLoad = useFirstLoadContext();
   const firstLoadDispatch = useFirstLoadDispatch();
   const interval = 100 / 14;
@@ -66,8 +70,9 @@ export default function EntryModal() {
       setLoadingMsg('Retrieving Quadrats...');
       response = await fetch(`/api/fixeddata/quadrats`, {method: 'GET'});
       setLoading(loading + interval);
+      let quadratRDS: GridValidRowModel[] = await response.json();
       if (quadratsLoadDispatch) {
-        quadratsLoadDispatch({quadratsLoad: await response.json()});
+        quadratsLoadDispatch({quadratsLoad: quadratRDS});
       }
       setLoading(loading + interval);
       setLoadingMsg('Retrieving Species...');
@@ -87,10 +92,19 @@ export default function EntryModal() {
       setLoadingMsg('Retrieving Plots...')
       response = await fetch(`/api/fixeddata/plots`, {method: 'GET'});
       setLoading(loading + interval);
+      let plotRDSLoad: GridValidRowModel[] = await response.json();
       if (plotsLoadDispatch) {
-        plotsLoadDispatch({plotsLoad: await response.json()});
+        plotsLoadDispatch({plotsLoad: plotRDSLoad});
+      }
+      let plotList: Plot[] = [];
+      for (const plotRDS of plotRDSLoad) {
+        plotList.push({key: plotRDS.plotName, num: quadratRDS.filter((quadrat) => quadrat.plotID == plotRDS.plotID).length});
+      }
+      if (plotsListDispatch) {
+        plotsListDispatch({plotList: plotList});
       }
       setLoading(100);
+      
     }
     fetchData().catch(console.error);
   }, []);

--- a/frontend/components/fileupload/filehandling.tsx
+++ b/frontend/components/fileupload/filehandling.tsx
@@ -3,10 +3,8 @@ import React, {useCallback, useState} from 'react';
 import {useSession} from "next-auth/react";
 import {DropzoneProps, DropzonePureProps, FileErrors, FileListProps, UploadValidationProps} from "@/config/macros";
 import {ValidationTable} from "@/components/fileupload/validationtable";
-import {usePlotContext} from "@/app/contexts/plotcontext";
-import {FileRejection, FileWithPath, useDropzone} from 'react-dropzone';
-import {parse, ParseConfig} from 'papaparse';
-import {FileUploadIcon} from "@/components/icons";
+import {usePlotContext} from "@/app/contexts/userselectioncontext";
+import {FileWithPath} from 'react-dropzone';
 
 import '@/styles/dropzone.css';
 import {subtitle} from "@/config/primitives";

--- a/frontend/components/fileupload/filehandling.tsx
+++ b/frontend/components/fileupload/filehandling.tsx
@@ -109,7 +109,7 @@ function UploadAndValidateFiles({
   );
 }
 
-export function Filehandling() {
+export function FileHandling() {
   const [acceptedFiles, setAcceptedFiles] = useState<FileWithPath[]>([]);
   const [isUploading, setIsUploading] = useState(false);
   const [errorsData, setErrorsData] = useState<FileErrors>({});

--- a/frontend/components/plotselection.tsx
+++ b/frontend/components/plotselection.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, {useEffect, useState} from "react";
-import {Plot, plots} from "@/config/macros";
-import {usePlotContext, usePlotDispatch} from "@/app/contexts/plotcontext";
+import {plots} from "@/config/macros";
+import {usePlotContext, usePlotDispatch} from "@/app/contexts/userselectioncontext";
 import {useSession} from "next-auth/react";
 import Select from "@mui/joy/Select";
 import Option from "@mui/joy/Option";

--- a/frontend/components/sidebar.tsx
+++ b/frontend/components/sidebar.tsx
@@ -12,15 +12,8 @@ import Typography from '@mui/joy/Typography';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import {LoginLogout} from "@/components/loginlogout";
 import {useSession} from "next-auth/react";
-import {allCensus, allQuadrats, plots, siteConfigNav, SiteConfigProps} from "@/config/macros";
-import {
-  useCensusContext,
-  useCensusDispatch,
-  usePlotContext,
-  usePlotDispatch,
-  useQuadratContext,
-  useQuadratDispatch
-} from "@/app/contexts/plotcontext";
+import {plots, siteConfigNav, SiteConfigProps} from "@/config/macros";
+import {usePlotContext, usePlotDispatch} from "@/app/contexts/plotcontext";
 import {usePathname, useRouter} from "next/navigation";
 import {
   Breadcrumbs,
@@ -76,17 +69,11 @@ function SimpleToggler({
 export default function Sidebar() {
   const currentPlot = usePlotContext();
   const plotDispatch = usePlotDispatch();
-  const currentCensus = useCensusContext();
-  const censusDispatch = useCensusDispatch();
-  const currentQuadrat = useQuadratContext();
-  const quadratDispatch = useQuadratDispatch();
   
   const [plot, setPlot] = useState<string | null>(null);
-  const [census, setCensus] = useState<number | null>(null);
-  const [quadrat, setQuadrat] = useState<number | null>(null);
   const [openSelectionModal, setOpenSelectionModal] = useState(false);
   const [activeStep, setActiveStep] = React.useState(0);
-  const steps = ["Plot", "Census", "Quadrat"];
+  const steps = ["Plot"];
   const router = useRouter();
   const pathname = usePathname();
   const containerRef = React.useRef<HTMLElement>(null);
@@ -299,27 +286,11 @@ export default function Sidebar() {
                   <Typography color={!currentPlot ? "danger" : undefined}
                               level="body-sm">Plot: {currentPlot ? currentPlot!.key : "None"}</Typography>
                 </Link>
-                <Link component={"button"} onClick={() => {
-                  setActiveStep(1);
-                  setOpenSelectionModal(true);
-                }}>
-                  <Typography color={!currentCensus ? "danger" : undefined}
-                              level="body-sm">Census: {currentCensus ? currentCensus : "None"}</Typography>
-                </Link>
-                <Link component={"button"} onClick={() => {
-                  setActiveStep(2);
-                  setOpenSelectionModal(true);
-                }}>
-                  <Typography color={!currentQuadrat ? "danger" : undefined}
-                              level="body-sm">Quadrat: {currentQuadrat ? currentQuadrat : "None"}</Typography>
-                </Link>
               </Breadcrumbs>
               <Divider orientation={"horizontal"}/>
               <Modal open={openSelectionModal} onClose={() => {
                 setActiveStep(0);
                 setPlot(null);
-                setCensus(null);
-                setQuadrat(null);
                 setOpenSelectionModal(false);
               }}>
                 <ModalDialog variant="outlined" role="alertdialog">
@@ -373,84 +344,27 @@ export default function Sidebar() {
                           </Select>
                         </Stack>
                       </Slide>
-                      <Slide appear in={activeStep == 1} direction={"right"} container={containerRef.current}>
-                        {/*<Stack direction={"column"} spacing={2} marginRight={15} marginTop={5}>*/}
-                        <Stack direction={"column"} spacing={2}>
-                          <Typography level={"title-sm"}>Select Census:</Typography>
-                          <Select
-                            placeholder="Select a Census"
-                            name="None"
-                            required
-                            autoFocus
-                            size={"sm"}
-                            onChange={(_event: React.SyntheticEvent | null, newValue: number | null,) => setCensus(newValue)}
-                          >
-                            <Option value={null}>None</Option>
-                            {allCensus.map((item) => (
-                              <Option value={item}>{item}</Option>
-                            ))}
-                          </Select>
-                        </Stack>
-                      </Slide>
-                      <Slide appear in={activeStep == 2} direction={"right"} container={containerRef.current}>
-                        {/*<Stack direction={"column"} spacing={2} marginLeft={5} marginTop={5}>*/}
-                        <Stack direction={"column"} spacing={2}>
-                          <Typography level={"title-sm"}>Select Quadrat:</Typography>
-                          <Select
-                            placeholder="Select a Quadrat"
-                            name="None"
-                            required
-                            autoFocus
-                            size={"sm"}
-                            onChange={(_event: React.SyntheticEvent | null, newValue: number | null,) => setQuadrat(newValue)}
-                          >
-                            <Option value={null}>None</Option>
-                            {allQuadrats.map((item) => (
-                              <Option value={item}>{item}</Option>
-                            ))}
-                          </Select>
-                        </Stack>
-                      </Slide>
                     </Box>
                   </DialogContent>
                   <DialogActions>
                     <Stack direction={"row"} spacing={2} divider={<Divider orientation={"vertical"}/>}>
-                      {activeStep > 0 ?
-                        <Button size={"sm"} variant={"soft"} onClick={() => setActiveStep(activeStep - 1)}>
-                          Previous
-                        </Button> : <Button size={"sm"} variant={"soft"} disabled>
-                          Previous
-                        </Button>}
                       <Button size={"sm"} color={"danger"} variant="soft" onClick={() => {
                         setActiveStep(0);
                         setPlot(null);
-                        setCensus(null);
-                        setQuadrat(null);
                         setOpenSelectionModal(false);
                       }}>
                         Cancel
                       </Button>
-                      {activeStep < 2 ? <Button size={"sm"} color={"primary"} variant={"soft"}
-                                                onClick={() => setActiveStep(activeStep + 1)}>
-                        Submit {steps[activeStep]}
-                      </Button> : <Button size={"sm"} variant={"soft"} color="success" onClick={() => {
+                      <Button size={"sm"} variant={"soft"} color="success" onClick={() => {
                         if (plotDispatch) {
                           plotDispatch({plotKey: plot});
                         }
-                        if (censusDispatch) {
-                          censusDispatch({census: census});
-                        }
-                        if (quadratDispatch) {
-                          quadratDispatch({quadrat: quadrat});
-                        }
                         setActiveStep(0);
                         setPlot(null);
-                        setCensus(null);
-                        setQuadrat(null);
                         setOpenSelectionModal(false);
                       }}>
                         Finish
-                      </Button>}
+                      </Button>
                     </Stack>
                   </DialogActions>
                 </ModalDialog>

--- a/frontend/components/sidebar.tsx
+++ b/frontend/components/sidebar.tsx
@@ -13,7 +13,7 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import {LoginLogout} from "@/components/loginlogout";
 import {useSession} from "next-auth/react";
 import {plots, siteConfigNav, SiteConfigProps} from "@/config/macros";
-import {usePlotContext, usePlotDispatch} from "@/app/contexts/plotcontext";
+import {usePlotContext, usePlotDispatch} from "@/app/contexts/userselectioncontext";
 import {usePathname, useRouter} from "next/navigation";
 import {
   Breadcrumbs,
@@ -36,6 +36,7 @@ import WarningRoundedIcon from "@mui/icons-material/WarningRounded";
 import {Check} from "@mui/icons-material";
 import Select from "@mui/joy/Select";
 import Option from '@mui/joy/Option';
+import {usePlotListContext} from "@/app/contexts/generalcontext";
 
 
 function SimpleToggler({
@@ -69,6 +70,7 @@ function SimpleToggler({
 export default function Sidebar() {
   const currentPlot = usePlotContext();
   const plotDispatch = usePlotDispatch();
+  const plotListContext = usePlotListContext()!;
   
   const [plot, setPlot] = useState<string | null>(null);
   const [openSelectionModal, setOpenSelectionModal] = useState(false);
@@ -338,8 +340,8 @@ export default function Sidebar() {
                             onChange={(_event: React.SyntheticEvent | null, newValue: string | null,) => setPlot(newValue)}
                           >
                             <Option value={null}>None</Option>
-                            {plots.map((keyItem) => (
-                              <Option value={keyItem.key}>{keyItem.key}</Option>
+                            {plotListContext.map((keyItem) => (
+                              <Option value={keyItem.key}>{keyItem.key}, Quadrats: {keyItem.num}</Option>
                             ))}
                           </Select>
                         </Stack>

--- a/frontend/components/uploadreviewcycle.tsx
+++ b/frontend/components/uploadreviewcycle.tsx
@@ -4,7 +4,7 @@ import {FileErrors, ReviewStates} from "@/config/macros";
 import {FileWithPath} from "react-dropzone";
 import {DataStructure, DisplayErrorTable, DisplayParsedData} from "@/components/fileupload/validationtable";
 import {parse} from "papaparse";
-import {usePlotContext} from "@/app/contexts/plotcontext";
+import {usePlotContext} from "@/app/contexts/userselectioncontext";
 import {useSession} from "next-auth/react";
 import {
   Button,

--- a/frontend/components/viewuploadedfiles.tsx
+++ b/frontend/components/viewuploadedfiles.tsx
@@ -3,7 +3,7 @@ import React, {useCallback, useEffect, useState} from 'react';
 import {fileColumns, tableHeaderSettings, UploadedFileData} from "@/config/macros";
 import {title} from "@/config/primitives";
 import {BrowseError} from "@/app/error"
-import {usePlotContext} from "@/app/contexts/plotcontext";
+import {usePlotContext} from "@/app/contexts/userselectioncontext";
 import {
   Button,
   Card,


### PR DESCRIPTION
Plot display and selection system needs to be dynamic based on database being logged into:

ChangeLog:

- Shifting hub layout SQL data collection system to EntryModal component and adding this to Login component --> EntryModal will now run AFTER logging in and BEFORE access to the rest of the application
- Implementing remaining SQL API routes for fixed data/properties pages
- Splitting contexts out into separate components --> BECAUSE list of plots will change depending on which database is being used, plot, quadrat, and census selection depends on updating plot list in order to select from the right dataset. By splitting plot list, quadrat list, and census list contexts into a separate parent context component and plot/quadrat/census selection contexts into a child context component, they can actually access the respective list contexts.
- Removing quadrat and census selection options from sidebar breadcrumbs menu --> the sidebar selection menu identifies selections that are core to all pages, and not all pages require quadrat or census selection.