### PR TITLE
frontend: Add tsc command for typechecking

### DIFF
--- a/frontend/app/(hub)/fileuploadhub/page.tsx
+++ b/frontend/app/(hub)/fileuploadhub/page.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import ViewUploadedFiles from "@/components/viewuploadedfiles";
 import {UploadAndReviewProcess} from "@/components/uploadreviewcycle";
 import {Tab, TabList, TabPanel, Tabs} from "@mui/joy";
-import {usePlotContext} from "@/app/contexts/plotcontext";
+// import {usePlotContext} from "@/app/contexts/plotcontext";
 import Box from "@mui/joy/Box";
 import Typography from "@mui/joy/Typography";
 

--- a/frontend/app/contexts/fixeddatacontext.tsx
+++ b/frontend/app/contexts/fixeddatacontext.tsx
@@ -163,6 +163,10 @@ export function useSpeciesLoadDispatch() {
   return useContext(SpeciesLoadDispatchContext);
 }
 
+export function useSubSpeciesLoadDispatch() {
+  return useContext(SubSpeciesLoadDispatchContext);
+}
+
 export function usePlotsLoadContext() {
   return useContext(PlotsLoadContext);
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "tsc": "tsc",
     "bs": "next build; next start",
     "clean": "rm -rf .next node_modules package-lock.json; npm install",
     "post-update": "echo \"codesandbox preview only, need an update\" && yarn upgrade --latest"


### PR DESCRIPTION
So `npm run tsc` works.

Note: there are a number of issues reported that are not fixed in this PR.