### PR TITLE
Hotfix -- Adding missing MySQL settings to ensure that server connection state is not automatically set to closed

### DIFF
--- a/frontend/components/processors/processormacros.tsx
+++ b/frontend/components/processors/processormacros.tsx
@@ -122,6 +122,8 @@ const sqlConfig: PoolOptions = {
   waitForConnections: true,
   connectionLimit: 10,
   queueLimit: 0,
+  keepAliveInitialDelay: 10000, // 0 by default.
+  enableKeepAlive: true, // false by default.
 };
 // database: process.env.AZURE_SQL_SCHEMA!, // better stored in an app setting such as process.env.DB_NAME
 export const poolMonitor = new PoolMonitor(sqlConfig);
@@ -280,3 +282,35 @@ export function buildPaginatedQuery(config: QueryConfig): { query: string, param
 
   return {query, params: queryParams};
 }
+
+// Function to close all active connections
+async function closeConnections() {
+  console.log('Closing all active connections...');
+  await poolMonitor.closeAllConnections();
+  console.log('All connections closed.');
+}
+
+// Function to handle graceful shutdown
+async function gracefulShutdown() {
+  console.log('Initiating graceful shutdown...');
+  try {
+    await closeConnections();
+    console.log('Graceful shutdown complete.');
+    process.exit(0);
+  } catch (error) {
+    console.error('Error during graceful shutdown:', error);
+    process.exit(1);
+  }
+}
+
+// Capture SIGINT signal (triggered by ctrl+c)
+process.on('SIGINT', async () => {
+  console.log('SIGINT signal received.');
+  await gracefulShutdown();
+});
+
+// Capture SIGTERM signal (triggered by process kill)
+process.on('SIGTERM', async () => {
+  console.log('SIGTERM signal received.');
+  await gracefulShutdown();
+});

--- a/frontend/config/poolmonitor.ts
+++ b/frontend/config/poolmonitor.ts
@@ -1,4 +1,4 @@
-import {Pool, PoolConnection, PoolOptions, createPool} from 'mysql2/promise';
+import { Pool, PoolConnection, PoolOptions, createPool } from 'mysql2/promise';
 
 export class PoolMonitor {
   private pool: Pool;
@@ -37,7 +37,6 @@ export class PoolMonitor {
     });
   }
 
-
   async getConnection(): Promise<PoolConnection> {
     try {
       console.log('Requesting new connection...');
@@ -52,5 +51,15 @@ export class PoolMonitor {
 
   getPoolStatus() {
     return `active: ${this.activeConnections} | total: ${this.totalConnectionsCreated} | waiting: ${this.waitingForConnection}`;
+  }
+
+  async closeAllConnections(): Promise<void> {
+    try {
+      await this.pool.end();
+      console.log('All connections closed.');
+    } catch (error) {
+      console.error('Error closing connections:', error);
+      throw error;
+    }
   }
 }


### PR DESCRIPTION
Adding additional emergency settings to ensure that connection is not automatically set to closed after mysql server is exited. Further incorporating graceful shutdown mechanism to ensure that in the rare case that leftover connections remain, they are properly closed.