### PR TITLE
ci(nightly): pin the nightly's checkouts to forestgeo-app-development

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,12 @@ jobs:
           --health-retries=10
 
     steps:
+      # The schedule fires on the default branch (main), but the nightly's job is to
+      # regression-test the integration branch where work lands first. Pin every
+      # checkout to forestgeo-app-development so the suite exercises dev, not main.
       - uses: actions/checkout@v4
+        with:
+          ref: forestgeo-app-development
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -128,6 +133,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: forestgeo-app-development
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -221,6 +228,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: forestgeo-app-development
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -276,6 +285,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: forestgeo-app-development
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -338,6 +349,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: forestgeo-app-development
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
The nightly has been failing on `main` (run 33163670926): `component` 8 of 14 specs failed, `full-cypress` 13 of 32. Nothing is newly broken — the suite is testing the wrong branch.

`schedule` events run the workflow file from the default branch, and `main`'s copy has five bare `actions/checkout@v4` steps with no `ref:`. So the whole nightly checks out `main`, which is currently 60 commits behind `forestgeo-app-development`.

`main` therefore lacks the Cypress component remediation merged to dev on 2026-08-26 (#442–#451). The headline failure is a case-sensitivity bug fixed by #443: `main` still resolves `next/navigation` to `cypress/mocks/nextNavMock.js` while the file is `nextnavmock.js`. That resolves on a case-insensitive macOS filesystem and fails on the Linux runner, producing `Module not found: Can't resolve 'next/navigation'` and taking out six specs at import time. The remaining failures match the specs realigned by #445 and #450.

This cherry-picks d3226d93 (from #453, already merged to dev) so the nightly regression-tests the integration branch where work actually lands, regardless of the branch the schedule fires from. After it, the file is byte-identical to dev's.

#453 cannot fix this on its own: scheduled workflows read the default branch's copy, so the pin only takes effect once it is on `main`.

## Scope

One file, one workflow. No application code, no schema, no test changes. The alternative fix is a dev→main promotion, which is the real remedy for `main` being stale but now also carries #456's two schema migrations to the live site — a separate decision.