### PR TITLE
fix(validations): seed validation 19 disabled so the deploy sweep stops enabling it

### DIFF
--- a/frontend/db/sql/corequeries.sql
+++ b/frontend/db/sql/corequeries.sql
@@ -368,15 +368,25 @@ ON DUPLICATE KEY UPDATE
     Definition = VALUES(Definition),
     IsEnabled = VALUES(IsEnabled);
 
--- IsEnabled = TRUE is deliberate here (unlike the migration, which seeds this
--- disabled): a fresh schema installs procedures and validations together, so
--- RunPlotCoordinateConsistencyValidation always exists by the time this runs.
+-- IsEnabled = FALSE, matching the migration that seeds this row. The earlier
+-- reasoning here ("a fresh schema installs procedures and validations together")
+-- is true for provisioning but not for the deploy path: this file is applied by
+-- deploy-validations-to-all-schemas in its default legacy-full-reset mode, which
+-- truncates and reseeds sitespecificvalidations on EVERY schema. Seeding TRUE
+-- therefore silently enabled validation 19 across all 12 production schemas on
+-- 2026-08-28, overriding the migration's deliberate disabled seed minutes after
+-- it ran.
+--
+-- Validation 19 is enabled per site, on purpose, via
+--   npm run activate:validation19
+-- which gates on the helper procedure and the measurement_errors row both being
+-- present. That gate is the only intended way to turn this on.
 INSERT INTO sitespecificvalidations (ValidationID, ProcedureName, Description, Criteria, Definition,
                                      ChangelogDefinition, IsEnabled)
 VALUES (19, 'ValidatePlotCoordinateConsistency',
         'Plot coordinate disagrees with the quadrat''s own median offset',
         'stemPlotX;stemPlotY;stemLocalX;stemLocalY;quadratName;treeTag;stemTag',
-        'CALL RunPlotCoordinateConsistencyValidation(@p_CensusID, @p_PlotID);', '', TRUE);
+        'CALL RunPlotCoordinateConsistencyValidation(@p_CensusID, @p_PlotID);', '', FALSE);
 
 truncate postvalidationqueries; -- clear the table if re-running this script on accident
 insert into postvalidationqueries

--- a/frontend/db/sql/storedprocedures.sql
+++ b/frontend/db/sql/storedprocedures.sql
@@ -1462,10 +1462,13 @@ and (@p_PlotID is null or c.PlotID = @p_PlotID);', '', true);
             'CALL RunSharedCrossCensusLocationValidations(@p_CensusID, @p_PlotID, 0, 1);', '', true);
     INSERT INTO sitespecificvalidations (ValidationID, ProcedureName, Description, Criteria, Definition,
                                          ChangelogDefinition, IsEnabled)
+    -- Seeded disabled, like the migration and corequeries.sql. Validation 19 is
+    -- turned on per site through `npm run activate:validation19`, which verifies
+    -- the helper procedure and error row first.
     VALUES (19, 'ValidatePlotCoordinateConsistency',
             'Plot coordinate disagrees with the quadrat''s own median offset',
             'stemPlotX;stemPlotY;stemLocalX;stemLocalY;quadratName;treeTag;stemTag',
-            'CALL RunPlotCoordinateConsistencyValidation(@p_CensusID, @p_PlotID);', '', true);
+            'CALL RunPlotCoordinateConsistencyValidation(@p_CensusID, @p_PlotID);', '', false);
     INSERT INTO sitespecificvalidations (ValidationID, ProcedureName, Description, Criteria, Definition,
                                          ChangelogDefinition, IsEnabled)
     VALUES (12, 'ValidateScreenStemsWithMeasurementsButDeadAttributes',

--- a/frontend/tests/integration/deploy-validations.test.ts
+++ b/frontend/tests/integration/deploy-validations.test.ts
@@ -53,6 +53,7 @@ describe('deploy-validations-to-all-schemas — integration', () => {
   let connection: Connection;
   let config: TestDatabaseConfig;
   let schema: string;
+  let seededValidation19Enabled: boolean | null;
   let procedureStatements: string[];
 
   beforeAll(async () => {
@@ -64,7 +65,16 @@ describe('deploy-validations-to-all-schemas — integration', () => {
     const storedprocsRaw = fs.readFileSync(path.join(process.cwd(), 'db/sql', 'storedprocedures.sql'), 'utf8');
     procedureStatements = parseStoredProceduresSQL(storedprocsRaw);
 
-    console.log(`[setup] schema=${schema} procedureStatements=${procedureStatements.length}`);
+    // Read the seeded state BEFORE beforeEach normalises it. setupTestDatabase has
+    // just run loadSchema -> corequeries.sql -> storedprocedures.sql, so this is
+    // exactly what a freshly provisioned schema ships with.
+    const [seeded] = await connection.query<RowDataPacket[]>(`SELECT IsEnabled FROM sitespecificvalidations WHERE ValidationID = 19`);
+    seededValidation19Enabled =
+      seeded.length === 0
+        ? null
+        : seeded[0].IsEnabled === 1 || seeded[0].IsEnabled === true || (Buffer.isBuffer(seeded[0].IsEnabled) && seeded[0].IsEnabled[0] === 1);
+
+    console.log(`[setup] schema=${schema} procedureStatements=${procedureStatements.length} seededValidation19Enabled=${seededValidation19Enabled}`);
   }, 120000);
 
   afterAll(async () => {
@@ -72,12 +82,10 @@ describe('deploy-validations-to-all-schemas — integration', () => {
   });
 
   beforeEach(async () => {
-    // setupTestDatabase's fresh schema (loadSchema -> corequeries.sql ->
-    // storedprocedures.sql) already seeds validation 19 as ENABLED, unlike
-    // the migration path which seeds it disabled — see corequeries.sql's
-    // comment on the INSERT. Every test in this file starts from a known,
-    // disabled baseline so the "activation actually flips it" assertions are
-    // meaningful.
+    // Normalise validation 19 to a known disabled baseline so the "activation
+    // actually flips it" assertions below are meaningful. The fresh schema now
+    // seeds it disabled too (see the seeded-default test), but this keeps each
+    // test independent of what the previous one left behind.
     await connection.query(
       `INSERT INTO sitespecificvalidations
          (ValidationID, ProcedureName, Description, Criteria, Definition, ChangelogDefinition, IsEnabled)
@@ -166,6 +174,19 @@ describe('deploy-validations-to-all-schemas — integration', () => {
   // -------------------------------------------------------------------------
   // activateValidation19
   // -------------------------------------------------------------------------
+
+  describe('seeded default', () => {
+    it('ships validation 19 DISABLED on a freshly provisioned schema', () => {
+      // Regression guard. corequeries.sql is applied by
+      // deploy-validations-to-all-schemas in its default legacy-full-reset mode,
+      // which truncates and reseeds sitespecificvalidations on every schema. When
+      // this seed said TRUE it enabled validation 19 across all 12 production
+      // schemas on 2026-08-28, overriding the migration's disabled seed. Enabling
+      // is meant to go through activateValidation19's gated path only.
+      expect(seededValidation19Enabled, 'validation 19 row must exist on a fresh schema').not.toBeNull();
+      expect(seededValidation19Enabled, 'a fresh schema must NOT ship validation 19 enabled').toBe(false);
+    });
+  });
 
   describe('activateValidation19', () => {
     it('enables validation 19 and verifies the row is enabled after UPDATE', async () => {


### PR DESCRIPTION
Validation 19 (`ValidatePlotCoordinateConsistency`) is enabled on **all 12 production schemas** and has been since 2026-08-28. Measured against the live server: `IsEnabled = 1` everywhere. It has written no findings — 0 rows in `measurement_error_log` for error code 19 — because nothing has been uploaded or revalidated since. The exposure is latent, not realised.

## How it happened

Migration `2026-08-27-02-seed-validation-19` seeds the row **disabled**, with a comment explaining that activation should wait until the helper procedure is verified present.

`corequeries.sql` seeded the same row `TRUE`, reasoning that "a fresh schema installs procedures and validations together, so RunPlotCoordinateConsistencyValidation always exists by the time this runs." That is correct for provisioning — but `corequeries.sql` is also what `deploy-validations-to-all-schemas` applies in its default `legacy-full-reset` mode, which truncates and reseeds `sitespecificvalidations` on every schema.

The dev deployment pipeline runs that script with no flags. So on 2026-08-28 the deploy step re-enabled validation 19 across every production schema, minutes after the migration had deliberately disabled it, in the same pipeline run.

## The change

Seed `FALSE` in both places that seed this row:

- `corequeries.sql` — the deploy sweep and provisioning
- `storedprocedures.sql` — the validation-reset procedure

Enabling stays with `npm run activate:validation19`, whose gate verifies the helper procedure and the `measurement_errors` row before flipping it. That gated path already exists and is the only intended way in.

## Why no test caught it

`deploy-validations.test.ts` forced `IsEnabled = FALSE` in `beforeEach` as a baseline, and its comment recorded the enabled seed as expected behaviour — so the seeded default was normalised away before any assertion could see it.

This captures the seeded value on the freshly loaded schema, before that normalisation, and asserts it is disabled. Verified by flipping the seed back to `TRUE`: the test fails with `a fresh schema must NOT ship validation 19 enabled`.

## Note on production state

This does not disable validation 19 on the 12 schemas that already have it on — it stops the next deploy sweep from re-enabling it. The next `deploy:validations` run will reseed those rows disabled.