### PR TITLE
ci: stop one ratchet drift failing two workflows, and absorb runner flake

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -56,14 +56,6 @@ jobs:
       - name: Install dependencies
         run: cd frontend && npm ci
 
-      - name: Dependency-cycle gate
-        run: node scripts/check-cycles.mjs
-        working-directory: frontend
-
-      - name: Any-escape count gate
-        run: node scripts/check-any-count.mjs
-        working-directory: frontend
-
       # The mysql service `--health-cmd` gates steps until MySQL is healthy, and
       # the seed's own connectWithRetry covers any residual TCP race.
       - name: Seed E2E database

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -10,6 +10,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The two ratchets live in ONE job, on purpose.
+  #
+  # They used to run as steps inside `unit` here AND inside `e2e-tests` in
+  # e2e-tests.yml. A single count over baseline therefore turned into two red
+  # workflows for one cause (see PR #456: any 490 vs baseline 489 failed both).
+  # Worse, they ran BEFORE the test steps, so a one-line drift aborted the job
+  # and discarded the entire unit/e2e signal — maximum noise, minimum
+  # information.
+  #
+  # As their own job the drift reports once, under a name that says what it is,
+  # and the test jobs still run and report independently.
+  gates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Dependency-cycle gate
+        run: node scripts/check-cycles.mjs
+        working-directory: frontend
+
+      - name: Any-escape count gate
+        run: node scripts/check-any-count.mjs
+        working-directory: frontend
+
   unit:
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -30,21 +65,16 @@ jobs:
         run: npm run build:check
         working-directory: frontend
 
-      - name: Dependency-cycle gate
-        run: node scripts/check-cycles.mjs
-        working-directory: frontend
-
-      - name: Any-escape count gate
-        run: node scripts/check-any-count.mjs
-        working-directory: frontend
-
       - name: Unit tests
         run: npm run test:unit
         working-directory: frontend
 
   integration:
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    # ~10 minutes on a healthy runner. Raised from 35 after run 33019550004 was
+    # killed mid-suite at the cap on a degraded runner — 3.5x headroom was not
+    # enough to survive one bad host.
+    timeout-minutes: 50
 
     services:
       mysql:

--- a/frontend/cypress.config.cjs
+++ b/frontend/cypress.config.cjs
@@ -4,6 +4,19 @@ const { defineConfig } = require('cypress');
 const { getSharedWebpackConfig, getLogTask } = require('./cypress/support/shared-config.cjs');
 
 module.exports = defineConfig({
+  // Retry failed specs in CI only. Several suites here are legitimately
+  // timing-sensitive — they drive a real Next dev server and a real MySQL — and
+  // a degraded shared runner turns that into red PRs unrelated to the change
+  // under review (e.g. PR #456's "Timed out after waiting 15000ms for your
+  // remote page to load", green on rerun).
+  //
+  // openMode stays 0 so local runs never hide a flake from the person writing
+  // the test. A genuine failure still fails all attempts, so this absorbs
+  // infrastructure noise without masking real breakage.
+  retries: {
+    runMode: 2,
+    openMode: 0
+  },
   e2e: {
     experimentalRunAllSpecs: true,
     experimentalInteractiveRunEvents: false,


### PR DESCRIPTION
Measured across the last 30 runs of each workflow: **PR Gate 3 failures, E2E Tests 3, Nightly 6 of 6.** Reading the failing *step* of every failed run groups them into two structural causes, neither of which is "a test broke":

| cause | failed runs |
|---|---|
| Nightly testing stale `main` | 6 |
| `Any-escape count gate` firing in two workflows for one commit | 2 |
| integration flake / deadlock | 1 |
| production contract skew | 1 |

## One drift, two red workflows

The ratchets ran as steps in both pr-gate's `unit` job and e2e-tests' `e2e-tests` job. A single count over baseline therefore produced two red workflows for one cause — #456 failed both with `any: 490 (baseline 489)`.

They also ran *before* the test steps, so a one-line drift aborted the job and discarded the entire unit and e2e signal. You learned nothing about whether the code worked.

Both ratchets now live in one `gates` job in pr-gate.yml, and the duplicates are gone from e2e-tests.yml. Drift reports once, under a name that says what it is, and the test jobs run and report independently. The deploy pipelines keep their own copies as a last line before shipping.

## No Cypress retries at all

`retries` was unset, i.e. zero, so every timing-sensitive spec was one degraded runner away from a red PR. #456 hit `Timed out after waiting 15000ms for your remote page to load` and was green on rerun.

Set `runMode: 2, openMode: 0`. Local runs never hide a flake from the person writing the test, and a genuine failure still fails all attempts — this absorbs infrastructure noise without masking breakage.

## Integration timeout

Raised 35 to 50 minutes. The suite takes ~10 on a healthy runner, but run 33019550004 was killed mid-suite at the cap. 3.5x headroom did not survive one bad host.

## Verification

Component 152/152, unit 260 files / 3933 passed, integration 123 files / 1101 passed, `npm run build` passes, `build:check` clean. Both ratchets still run and still report (`cycles: 33 (baseline 33)`, `any: 488 (baseline 489)`). Both workflow files parse; pr-gate now exposes `gates`, `unit`, `integration`, `component`.

## Not addressed here

The nightly's 6 of 6 came from testing stale `main` and is already fixed by #458 — tonight's run is the first with the pin, still unverified.

The two deliberately timing-dependent suites, `ingestion-scale-benchmark` (measures latency) and `ingest-batch-kill-boundary` (kills a running query), still gate PRs. Both are inherently runner-sensitive and are better suited to the nightly than to the PR gate, but moving them is a separate call about coverage.