### PR TITLE
fix(uploads): make rejected upload rows legible to researchers

### DIFF
--- a/frontend/app/api/batchedupload/[schema]/[[...slugs]]/route.test.ts
+++ b/frontend/app/api/batchedupload/[schema]/[[...slugs]]/route.test.ts
@@ -147,6 +147,18 @@ describe('batchedupload POST route', () => {
     expect(validatedSchemaMock).toHaveBeenCalledWith('forestgeo_testing');
   });
 
+  it('does not accept malformed or unsafe numeric URL parameters in the fallback path', async () => {
+    validateContextualValuesMock.mockResolvedValueOnce({
+      success: false,
+      response: new Response(JSON.stringify({ message: 'context validation failed' }), { status: 400 })
+    });
+    const req = makeRequest([{ treeID: 1, reason: 'bad' }]);
+    const res = await POST(req, makeParams('forestgeo_testing', ['1junk', '-2']));
+
+    expect(res.status).toBe(400);
+    expect(recordFailedMeasurementRows).not.toHaveBeenCalled();
+  });
+
   it('carries plotX/plotY through untouched to recordFailedMeasurementRows (route only maps plotID/censusID/batchID/fileID)', async () => {
     const payload = [
       { treeID: 10, stemGUID: 20, reason: 'coordinate drift', plotX: -0.271, plotY: 267.5 },

--- a/frontend/app/api/batchedupload/[schema]/[[...slugs]]/route.ts
+++ b/frontend/app/api/batchedupload/[schema]/[[...slugs]]/route.ts
@@ -4,6 +4,7 @@ import { FailedMeasurementsRDS } from '@/lib/db/definitions/core';
 import connectionmanager from '@/lib/db/connectionmanager';
 import { validateContextualValues } from '@/lib/contextvalidation';
 import ailogger from '@/ailogger';
+import { toError } from '@/lib/errorhelpers';
 import { recordFailedMeasurementRows } from '@/lib/uploads/record-invalid-rows';
 import { generateShortBatchID } from '@/config/utils';
 import { validatedSchema, type SchemaName } from '@/lib/db/sqlsecurity';
@@ -130,7 +131,7 @@ export async function POST(request: NextRequest, props: { params: Promise<{ sche
       await connectionManager.closeConnection();
     } catch (closeError) {
       if (operationError === undefined) throw closeError;
-      ailogger.error('Failed to close batch upload connection after the primary error:', closeError);
+      ailogger.error('Failed to close batch upload connection after the primary error:', toError(closeError));
     }
   }
 }

--- a/frontend/app/api/batchedupload/[schema]/[[...slugs]]/route.ts
+++ b/frontend/app/api/batchedupload/[schema]/[[...slugs]]/route.ts
@@ -51,10 +51,13 @@ export async function POST(request: NextRequest, props: { params: Promise<{ sche
     // caller to act on any schema matching the pattern.
     if (schemaParam && slugs && slugs.length === 2) {
       const [plotIDParam, censusIDParam] = slugs;
-      plotID = parseInt(plotIDParam);
-      censusID = parseInt(censusIDParam);
+      if (!/^[1-9]\d*$/.test(plotIDParam) || !/^[1-9]\d*$/.test(censusIDParam)) {
+        return new NextResponse(JSON.stringify({ message: 'Invalid plotID or censusID in URL parameters!' }), { status: HTTPResponses.INVALID_REQUEST });
+      }
+      plotID = Number(plotIDParam);
+      censusID = Number(censusIDParam);
 
-      if (isNaN(plotID) || isNaN(censusID)) {
+      if (!Number.isSafeInteger(plotID) || !Number.isSafeInteger(censusID)) {
         return new NextResponse(JSON.stringify({ message: 'Invalid plotID or censusID in URL parameters!' }), { status: HTTPResponses.INVALID_REQUEST });
       }
 
@@ -90,14 +93,18 @@ export async function POST(request: NextRequest, props: { params: Promise<{ sche
     ...row,
     plotID,
     censusID,
-    batchID: (row as any).batchID ?? batchID,
-    fileID: (row as any).fileID ?? fileID,
+    // These identifiers are generated/request-scoped values, never client
+    // overrides. Otherwise one rejected row could be persisted under another
+    // upload's file/batch and later be selected by the wrong retry.
+    batchID,
+    fileID,
     originalFailureReasons: row.originalFailureReasons ?? row.failureReasons ?? undefined,
     currentFailureReasons: row.currentFailureReasons ?? row.failureReasons ?? undefined
   }));
 
   const connectionManager = connectionmanager.getInstance();
   let transactionID = '';
+  let operationError: unknown;
 
   try {
     transactionID = await connectionManager.beginTransaction();
@@ -106,12 +113,24 @@ export async function POST(request: NextRequest, props: { params: Promise<{ sche
 
     return new NextResponse(JSON.stringify({ message: 'Inserted ingestion error rows', rowCount: errorRows.length }), { status: HTTPResponses.OK });
   } catch (error: any) {
+    operationError = error;
     if (transactionID) {
-      await connectionManager.rollbackTransaction(transactionID);
+      try {
+        await connectionManager.rollbackTransaction(transactionID);
+      } catch (rollbackError) {
+        if (error instanceof Error) {
+          (error as Error & { rollbackError?: unknown }).rollbackError = rollbackError;
+        }
+      }
     }
     ailogger.error('Database Error:', error);
     return new NextResponse(JSON.stringify({ message: 'Database error', error: error.message }), { status: HTTPResponses.INTERNAL_SERVER_ERROR });
   } finally {
-    await connectionManager.closeConnection();
+    try {
+      await connectionManager.closeConnection();
+    } catch (closeError) {
+      if (operationError === undefined) throw closeError;
+      ailogger.error('Failed to close batch upload connection after the primary error:', closeError);
+    }
   }
 }

--- a/frontend/app/api/revisionupload/apply/route.test.ts
+++ b/frontend/app/api/revisionupload/apply/route.test.ts
@@ -223,6 +223,8 @@ function buildDbRow(coreMeasurementID: number, overrides: Record<string, unknown
     QuadratName: 'Q',
     LocalX: 0,
     LocalY: 0,
+    StemPlotX: null,
+    StemPlotY: null,
     ...overrides
   };
 }
@@ -410,6 +412,10 @@ describe('POST /api/revisionupload/apply', () => {
   });
 
   it('stages new rows with plot coordinates into temporarymeasurements PlotX/PlotY', async () => {
+    mocks.executeQuery.mockImplementation(async (query: string) => {
+      if (query.includes('INSERT INTO ??.temporarymeasurements')) return { affectedRows: 1, warningStatus: 0 };
+      return [];
+    });
     const response = await POST(
       buildRequest(
         buildValidBody({
@@ -438,7 +444,7 @@ describe('POST /api/revisionupload/apply', () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({ insertedCount: 1 });
 
-    const insertCall = mocks.executeQuery.mock.calls.find(([sql]) => typeof sql === 'string' && sql.includes('INSERT IGNORE INTO ??.temporarymeasurements'));
+    const insertCall = mocks.executeQuery.mock.calls.find(([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO ??.temporarymeasurements'));
     expect(insertCall).toBeDefined();
     const [insertSQL, insertParams] = insertCall!;
     expect(insertSQL).toContain('LocalX, LocalY, PlotX, PlotY, DBH, HOM');
@@ -463,11 +469,70 @@ describe('POST /api/revisionupload/apply', () => {
 
     expect(response.status).toBe(422);
     await expect(response.json()).resolves.toEqual({ error: 'invalid field value', field: 'MeasuredDBH' });
-    expect(mocks.executeQuery).not.toHaveBeenCalledWith(
-      expect.stringContaining('INSERT IGNORE INTO ??.temporarymeasurements'),
-      expect.anything(),
-      expect.anything()
+    expect(mocks.executeQuery).not.toHaveBeenCalledWith(expect.stringContaining('INSERT INTO ??.temporarymeasurements'), expect.anything(), expect.anything());
+  });
+
+  it('rejects out-of-range plot coordinates before inserting temporary measurements', async () => {
+    const response = await POST(
+      buildRequest(
+        buildValidBody({
+          newRows: [{ csvIndex: 0, csvRow: { tag: 'T1', px: '1000000' } }],
+          confirmNewRows: true
+        })
+      )
     );
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toEqual({ error: 'invalid field value', field: 'StemPlotX' });
+    expect(mocks.executeQuery).not.toHaveBeenCalledWith(expect.stringContaining('INSERT INTO ??.temporarymeasurements'), expect.anything(), expect.anything());
+  });
+
+  it('rolls back revision staging when MySQL reports a warning and surfaces its details', async () => {
+    mocks.executeQuery.mockImplementation(async (query: string) => {
+      if (query.includes('INSERT INTO ??.temporarymeasurements')) return { affectedRows: 1, warningStatus: 1 };
+      if (query === 'SHOW WARNINGS') return [{ Level: 'Warning', Code: 1265, Message: "Data truncated for column 'PlotX'" }];
+      return [];
+    });
+
+    const response = await POST(
+      buildRequest(
+        buildValidBody({
+          newRows: [{ csvIndex: 0, csvRow: { tag: 'T1', px: '12.5' } }],
+          confirmNewRows: true
+        })
+      )
+    );
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toEqual({
+      error: "Revision staging produced 1 SQL warning(s): Warning 1265 Data truncated for column 'PlotX'"
+    });
+    expect(mocks.executeQuery).not.toHaveBeenCalledWith(expect.stringContaining('CALL ??.bulkingestionprocess'), expect.anything(), expect.anything());
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      '[revisionupload/apply] temporarymeasurement staging produced SQL warnings',
+      undefined,
+      expect.objectContaining({ warningCount: 1 })
+    );
+  });
+
+  it('rejects a staging row-count mismatch instead of reporting the requested count as inserted', async () => {
+    mocks.executeQuery.mockImplementation(async (query: string) => {
+      if (query.includes('INSERT INTO ??.temporarymeasurements')) return { affectedRows: 0, warningStatus: 0 };
+      return [];
+    });
+
+    const response = await POST(
+      buildRequest(
+        buildValidBody({
+          newRows: [{ csvIndex: 0, csvRow: { tag: 'T1', px: '12.5' } }],
+          confirmNewRows: true
+        })
+      )
+    );
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toEqual({ error: 'Revision staging inserted 0 of 1 expected row(s)' });
+    expect(mocks.executeQuery).not.toHaveBeenCalledWith(expect.stringContaining('CALL ??.bulkingestionprocess'), expect.anything(), expect.anything());
   });
 
   it('returns 409 with freshPlan when the bulk plan hash drifts between match and apply', async () => {

--- a/frontend/app/api/revisionupload/apply/route.test.ts
+++ b/frontend/app/api/revisionupload/apply/route.test.ts
@@ -508,6 +508,14 @@ describe('POST /api/revisionupload/apply', () => {
       error: "Revision staging produced 1 SQL warning(s): Warning 1265 Data truncated for column 'PlotX'"
     });
     expect(mocks.executeQuery).not.toHaveBeenCalledWith(expect.stringContaining('CALL ??.bulkingestionprocess'), expect.anything(), expect.anything());
+
+    // SHOW WARNINGS must go through the text protocol. runQuery routes to
+    // connection.execute() whenever a params array is supplied, and MySQL
+    // rejects SHOW WARNINGS there with ER_UNSUPPORTED_PS (1295) — which would
+    // throw an opaque 500 over the very diagnostic this branch exists to read.
+    const showWarningsCall = mocks.executeQuery.mock.calls.find(([query]: [string]) => query === 'SHOW WARNINGS');
+    expect(showWarningsCall).toBeDefined();
+    expect(showWarningsCall![1]).toBeUndefined();
     expect(mocks.loggerError).toHaveBeenCalledWith(
       '[revisionupload/apply] temporarymeasurement staging produced SQL warnings',
       undefined,

--- a/frontend/app/api/revisionupload/apply/route.test.ts
+++ b/frontend/app/api/revisionupload/apply/route.test.ts
@@ -409,6 +409,48 @@ describe('POST /api/revisionupload/apply', () => {
     );
   });
 
+  it('stages new rows with plot coordinates into temporarymeasurements PlotX/PlotY', async () => {
+    const response = await POST(
+      buildRequest(
+        buildValidBody({
+          newRows: [
+            {
+              csvIndex: 0,
+              csvRow: {
+                tag: 'T9',
+                stemtag: 'S9',
+                spcode: 'AAA',
+                quadrat: 'Q1',
+                lx: '3.5',
+                ly: '4.25',
+                px: '-2.531244',
+                py: '487.125',
+                dbh: '10',
+                date: '2026-04-01'
+              }
+            }
+          ],
+          confirmNewRows: true
+        })
+      )
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ insertedCount: 1 });
+
+    const insertCall = mocks.executeQuery.mock.calls.find(([sql]) => typeof sql === 'string' && sql.includes('INSERT IGNORE INTO ??.temporarymeasurements'));
+    expect(insertCall).toBeDefined();
+    const [insertSQL, insertParams] = insertCall!;
+    expect(insertSQL).toContain('LocalX, LocalY, PlotX, PlotY, DBH, HOM');
+    const rowValues = (insertParams as unknown[][])[0][0] as unknown[];
+    // Column order: FileID, BatchID, PlotID, CensusID, TreeTag, StemTag,
+    // SpeciesCode, QuadratName, LocalX, LocalY, PlotX, PlotY, DBH, HOM, ...
+    expect(rowValues[8]).toBe(3.5);
+    expect(rowValues[9]).toBe(4.25);
+    expect(rowValues[10]).toBe(-2.531244);
+    expect(rowValues[11]).toBe(487.125);
+  });
+
   it('rejects malformed numeric values in new rows before inserting temporary measurements', async () => {
     const response = await POST(
       buildRequest(

--- a/frontend/app/api/revisionupload/apply/route.ts
+++ b/frontend/app/api/revisionupload/apply/route.ts
@@ -6,6 +6,7 @@ import { HTTPResponses } from '@/config/macros';
 import { FileRow } from '@/config/macros/formdetails';
 import { generateShortBatchID } from '@/config/utils';
 import ailogger from '@/ailogger';
+import { toError } from '@/lib/errorhelpers';
 import { ACTIVE_UPLOAD_SESSION_STATES, ensureUploadSessionsTable } from '@/config/uploadsessiontracker';
 import { buildMeasurementScopeLockName, MEASUREMENT_SCOPE_LOCK_TIMEOUT_MS } from '@/config/measurementscopelock';
 import { ACTIVE_UPLOAD_SESSION_HEARTBEAT_TIMEOUT_SECONDS, STALE_VALIDATION_RUN_THRESHOLD_MINUTES } from '@/config/measurementscopepolicy';
@@ -1053,7 +1054,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       await connectionManager.closeConnection();
     } catch (closeError) {
       if (operationError === undefined) throw closeError;
-      ailogger.error(`${logPrefix} failed to close connection after the primary error:`, closeError);
+      ailogger.error(`${logPrefix} failed to close connection after the primary error:`, toError(closeError));
     }
   }
 }

--- a/frontend/app/api/revisionupload/apply/route.ts
+++ b/frontend/app/api/revisionupload/apply/route.ts
@@ -47,6 +47,13 @@ class RevisionApplyPlanHashMismatchError extends Error {
   }
 }
 
+class RevisionStagingIntegrityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RevisionStagingIntegrityError';
+  }
+}
+
 interface ApplyMatchedRow {
   csvIndex?: number;
   coreMeasurementID: number;
@@ -139,6 +146,24 @@ function getAffectedRowCount(result: unknown): number {
 
   const affectedRows = (result as { affectedRows?: unknown }).affectedRows;
   return typeof affectedRows === 'number' && Number.isFinite(affectedRows) ? affectedRows : 0;
+}
+
+function getWarningCount(result: unknown): number {
+  if (!result || typeof result !== 'object' || !('warningStatus' in result)) return 0;
+  const warningStatus = (result as { warningStatus?: unknown }).warningStatus;
+  return typeof warningStatus === 'number' && Number.isFinite(warningStatus) ? warningStatus : 0;
+}
+
+function describeSqlWarnings(warnings: unknown): string {
+  if (!Array.isArray(warnings) || warnings.length === 0) return 'warning details unavailable';
+  return warnings
+    .slice(0, 5)
+    .map(warning => {
+      if (!warning || typeof warning !== 'object') return String(warning);
+      const row = warning as { Code?: unknown; Message?: unknown; Level?: unknown };
+      return [row.Level, row.Code, row.Message].filter(value => value !== undefined && value !== null && value !== '').join(' ');
+    })
+    .join('; ');
 }
 
 interface MatchedRowWithDiff {
@@ -589,16 +614,40 @@ async function insertNewRowsThroughPipeline(
 
   const insertTempSQL = safeFormatQuery(
     schema,
-    `INSERT IGNORE INTO ??.temporarymeasurements
+    `INSERT INTO ??.temporarymeasurements
       (FileID, BatchID, PlotID, CensusID, TreeTag, StemTag, SpeciesCode, QuadratName, LocalX, LocalY, PlotX, PlotY, DBH, HOM, MeasurementDate, Codes, Comments)
      VALUES ?`
   );
-  await connectionManager.executeQuery(insertTempSQL, [rowValues], transactionID);
+  const insertResult = await connectionManager.executeQuery(insertTempSQL, [rowValues], transactionID);
+  const stagedCount = getAffectedRowCount(insertResult);
+  const warningCount = getWarningCount(insertResult);
+
+  if (warningCount > 0) {
+    const warnings = await connectionManager.executeQuery('SHOW WARNINGS', [], transactionID);
+    const warningDetail = describeSqlWarnings(warnings);
+    ailogger.error('[revisionupload/apply] temporarymeasurement staging produced SQL warnings', undefined, {
+      schema,
+      batchID,
+      warningCount,
+      warningDetail
+    });
+    throw new RevisionStagingIntegrityError(`Revision staging produced ${warningCount} SQL warning(s): ${warningDetail}`);
+  }
+
+  if (stagedCount !== newRows.length) {
+    ailogger.error('[revisionupload/apply] temporarymeasurement staging row-count mismatch', undefined, {
+      schema,
+      batchID,
+      expectedRows: newRows.length,
+      stagedRows: stagedCount
+    });
+    throw new RevisionStagingIntegrityError(`Revision staging inserted ${stagedCount} of ${newRows.length} expected row(s)`);
+  }
 
   const bulkIngestSQL = safeFormatQuery(schema, 'CALL ??.bulkingestionprocess(?, ?)');
   await connectionManager.executeQuery(bulkIngestSQL, [REVISION_UPLOAD_FILE_ID, batchID], transactionID);
 
-  return newRows.length;
+  return stagedCount;
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -987,6 +1036,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
     if (errorObj instanceof InvalidFieldValueError) {
       return NextResponse.json({ error: 'invalid field value', field: errorObj.field }, { status: HTTPResponses.UNPROCESSABLE_ENTITY });
+    }
+    if (errorObj instanceof RevisionStagingIntegrityError) {
+      return NextResponse.json({ error: errorObj.message }, { status: HTTPResponses.UNPROCESSABLE_ENTITY });
     }
     const status = errorObj instanceof RevisionApplyConflictError ? HTTPResponses.CONFLICT : HTTPResponses.INTERNAL_SERVER_ERROR;
     return NextResponse.json({ error: errorObj.message }, { status });

--- a/frontend/app/api/revisionupload/apply/route.ts
+++ b/frontend/app/api/revisionupload/apply/route.ts
@@ -577,6 +577,8 @@ async function insertNewRowsThroughPipeline(
       canonical.QuadratName ?? null,
       canonical.StemLocalX ?? null,
       canonical.StemLocalY ?? null,
+      canonical.StemPlotX ?? null,
+      canonical.StemPlotY ?? null,
       canonical.MeasuredDBH ?? null,
       canonical.MeasuredHOM ?? null,
       canonical.MeasurementDate ?? null,
@@ -588,7 +590,7 @@ async function insertNewRowsThroughPipeline(
   const insertTempSQL = safeFormatQuery(
     schema,
     `INSERT IGNORE INTO ??.temporarymeasurements
-      (FileID, BatchID, PlotID, CensusID, TreeTag, StemTag, SpeciesCode, QuadratName, LocalX, LocalY, DBH, HOM, MeasurementDate, Codes, Comments)
+      (FileID, BatchID, PlotID, CensusID, TreeTag, StemTag, SpeciesCode, QuadratName, LocalX, LocalY, PlotX, PlotY, DBH, HOM, MeasurementDate, Codes, Comments)
      VALUES ?`
   );
   await connectionManager.executeQuery(insertTempSQL, [rowValues], transactionID);

--- a/frontend/app/api/revisionupload/apply/route.ts
+++ b/frontend/app/api/revisionupload/apply/route.ts
@@ -669,7 +669,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   let body: ApplyRequest;
   try {
-    body = await request.json();
+    const parsedBody: unknown = await request.json();
+    if (parsedBody === null || typeof parsedBody !== 'object' || Array.isArray(parsedBody)) {
+      return NextResponse.json({ error: 'Request body must be a JSON object' }, { status: HTTPResponses.INVALID_REQUEST });
+    }
+    body = parsedBody as ApplyRequest;
   } catch {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: HTTPResponses.INVALID_REQUEST });
   }
@@ -757,6 +761,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   const connectionManager = ConnectionManager.getInstance();
+  let operationError: unknown;
 
   try {
     await assertCanEditMeasurementScope(connectionManager, session!, {
@@ -1006,6 +1011,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json(response, { status: HTTPResponses.OK });
   } catch (error: unknown) {
     const errorObj = error instanceof Error ? error : new Error(String(error));
+    operationError = errorObj;
     ailogger.error(`${logPrefix} request failed after ${Date.now() - requestStartedAt}ms:`, errorObj);
     if (errorObj instanceof SessionExpiredError) {
       return NextResponse.json({ error: 'session expired' }, { status: HTTPResponses.UNAUTHORIZED });
@@ -1043,6 +1049,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const status = errorObj instanceof RevisionApplyConflictError ? HTTPResponses.CONFLICT : HTTPResponses.INTERNAL_SERVER_ERROR;
     return NextResponse.json({ error: errorObj.message }, { status });
   } finally {
-    await connectionManager.closeConnection();
+    try {
+      await connectionManager.closeConnection();
+    } catch (closeError) {
+      if (operationError === undefined) throw closeError;
+      ailogger.error(`${logPrefix} failed to close connection after the primary error:`, closeError);
+    }
   }
 }

--- a/frontend/app/api/revisionupload/apply/route.ts
+++ b/frontend/app/api/revisionupload/apply/route.ts
@@ -624,7 +624,10 @@ async function insertNewRowsThroughPipeline(
   const warningCount = getWarningCount(insertResult);
 
   if (warningCount > 0) {
-    const warnings = await connectionManager.executeQuery('SHOW WARNINGS', [], transactionID);
+    // SHOW WARNINGS is rejected by the prepared-statement protocol (ER_UNSUPPORTED_PS 1295).
+    // Passing no params keeps runQuery on connection.query(), so the diagnostic this branch
+    // exists to surface is actually readable instead of throwing over the real failure.
+    const warnings = await connectionManager.executeQuery('SHOW WARNINGS', undefined, transactionID);
     const warningDetail = describeSqlWarnings(warnings);
     ailogger.error('[revisionupload/apply] temporarymeasurement staging produced SQL warnings', undefined, {
       schema,

--- a/frontend/app/api/revisionupload/route.test.ts
+++ b/frontend/app/api/revisionupload/route.test.ts
@@ -310,6 +310,61 @@ describe('POST /api/revisionupload', () => {
     });
   });
 
+  it('demotes only the row with an out-of-range cell, instead of 422ing the whole file with no row locator', async () => {
+    // computeDiff canonicalizes numeric cells, so one bad value used to throw
+    // out of the match loop and reject every row in the upload with a bare
+    // field name — unusable on a 10,000-row revision file.
+    const MATCHED_ROWS = [
+      { CoreMeasurementID: 777, RawTreeTag: 'TREE-7', TreeTag: 'TREE-7', StemTag: '2', RawStemTag: '2' },
+      { CoreMeasurementID: 778, RawTreeTag: 'TREE-8', TreeTag: 'TREE-8', StemTag: '2', RawStemTag: '2' }
+    ];
+
+    mocks.executeQuery.mockImplementation(async (query: string) => {
+      if (query.includes("LOWER(TRIM(COALESCE(t.TreeTag, cm.RawTreeTag, '')))")) {
+        return MATCHED_ROWS.map(row => ({
+          ...row,
+          StemGUID: row.CoreMeasurementID,
+          IsActive: 1,
+          MeasuredDBH: 12.4,
+          MeasuredHOM: 1.1,
+          MeasurementDate: '2025-05-01',
+          RawCodes: null,
+          Description: null,
+          StemIsActive: 1,
+          TreeIsActive: 1,
+          QuadratIsActive: 1,
+          PlotID: 1,
+          SpeciesCode: 'AAAAAA',
+          QuadratName: '101',
+          LocalX: 1.5,
+          LocalY: 2.5
+        }));
+      }
+      return [];
+    });
+
+    const response = await POST(
+      buildRequest({
+        rows: [
+          { tag: 'TREE-7', stemtag: '2', dbh: '12.8' },
+          { tag: 'TREE-8', stemtag: '2', dbh: '9999999' }
+        ],
+        plotID: 1,
+        censusID: 2,
+        schema: 'forestgeo_testing'
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.matchedRows).toHaveLength(1);
+    expect(body.matchedRows[0].csvIndex).toBe(0);
+    expect(body.invalidRows).toHaveLength(1);
+    expect(body.invalidRows[0].csvIndex).toBe(1);
+    expect(body.invalidRows[0].reason).toMatch(/MeasuredDBH/);
+  });
+
   it('flags duplicate stemid rows within a single file as invalid instead of silently collapsing them', async () => {
     mocks.executeQuery.mockResolvedValue([]);
 

--- a/frontend/app/api/revisionupload/route.ts
+++ b/frontend/app/api/revisionupload/route.ts
@@ -380,13 +380,30 @@ async function classifyFileRows(
         .map(row => row.CoreMeasurementID)
         .sort((left, right) => left - right);
 
+      // computeDiff canonicalizes numeric cells, so one malformed or
+      // out-of-range value throws. Demote that row to invalid with its CSV
+      // index instead of letting it 422 the whole file, which left the
+      // researcher with a field name and no way to find the offending row.
+      let changes: Record<string, { from: unknown; to: unknown }>;
+      try {
+        changes = computeDiff(candidate.csvRow, survivor);
+      } catch (diffError: unknown) {
+        if (!(diffError instanceof InvalidFieldValueError)) throw diffError;
+        invalidRows.push({
+          csvRow: candidate.csvRow,
+          csvIndex: candidate.csvIndex,
+          reason: diffError.message
+        });
+        continue;
+      }
+
       matchedRows.push({
         csvIndex: candidate.csvIndex,
         csvRow: candidate.csvRow,
         coreMeasurementID: survivor.CoreMeasurementID,
         duplicateMeasurementIDsToDelete,
         existingValues: buildExistingValues(survivor),
-        changes: computeDiff(candidate.csvRow, survivor)
+        changes
       });
       continue;
     }

--- a/frontend/app/api/revisionupload/shared/matchdiff.test.ts
+++ b/frontend/app/api/revisionupload/shared/matchdiff.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { computeDiff, ExistingMeasurementRow } from './matchdiff';
 import type { FileRow } from '@/config/macros/formdetails';
+import { InvalidFieldValueError } from '@/config/editplan/fieldpolicy';
 
 function makeDbRow(overrides: Partial<ExistingMeasurementRow> = {}): ExistingMeasurementRow {
   return {
@@ -67,5 +68,26 @@ describe('computeDiff plot coordinates', () => {
     const csvRow = { px: '100.500000' } as unknown as FileRow;
 
     expect(computeDiff(csvRow, dbRow).px).toBeUndefined();
+  });
+
+  it('compares the six-decimal canonical value so excess precision does not create a phantom change', () => {
+    const dbRow = makeDbRow({ StemPlotX: 100.123456 });
+    const csvRow = { px: '100.1234564' } as unknown as FileRow;
+
+    expect(computeDiff(csvRow, dbRow).px).toBeUndefined();
+  });
+
+  it('rejects malformed numeric prefixes even when parseFloat would match the stored value', () => {
+    const dbRow = makeDbRow({ StemPlotX: 100 });
+    const csvRow = { px: '100abc' } as unknown as FileRow;
+
+    expect(() => computeDiff(csvRow, dbRow)).toThrow(InvalidFieldValueError);
+  });
+
+  it('rejects plot coordinates outside DECIMAL(12,6)', () => {
+    const dbRow = makeDbRow({ StemPlotX: 100 });
+    const csvRow = { px: '1000000' } as unknown as FileRow;
+
+    expect(() => computeDiff(csvRow, dbRow)).toThrow(InvalidFieldValueError);
   });
 });

--- a/frontend/app/api/revisionupload/shared/matchdiff.test.ts
+++ b/frontend/app/api/revisionupload/shared/matchdiff.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { computeDiff, ExistingMeasurementRow } from './matchdiff';
+import type { FileRow } from '@/config/macros/formdetails';
+
+function makeDbRow(overrides: Partial<ExistingMeasurementRow> = {}): ExistingMeasurementRow {
+  return {
+    CoreMeasurementID: 1,
+    StemGUID: 10,
+    IsActive: 1,
+    MeasuredDBH: 12.3,
+    MeasuredHOM: 1.3,
+    MeasurementDate: '2026-04-01',
+    RawCodes: null,
+    Description: null,
+    RawTreeTag: 'T1',
+    RawStemTag: 'S1',
+    StemIsActive: 1,
+    TreeIsActive: 1,
+    QuadratIsActive: 1,
+    PlotID: 1,
+    TreeTag: 'T1',
+    StemTag: 'S1',
+    SpeciesCode: 'ACERRU',
+    QuadratName: 'Q1',
+    LocalX: 3.5,
+    LocalY: 4.25,
+    StemPlotX: null,
+    StemPlotY: null,
+    ...overrides
+  };
+}
+
+describe('computeDiff plot coordinates', () => {
+  it('flags a px/py change against the stored plot coordinates', () => {
+    const dbRow = makeDbRow({ StemPlotX: 100.123456, StemPlotY: 200.5 });
+    const csvRow = { px: '-2.75', py: '200.5' } as unknown as FileRow;
+
+    const changes = computeDiff(csvRow, dbRow);
+
+    expect(changes.px).toEqual({ from: '100.123456', to: '-2.75' });
+    // py matches numerically → no phantom change.
+    expect(changes.py).toBeUndefined();
+  });
+
+  it('fills plot coordinates on a row that has none', () => {
+    const dbRow = makeDbRow();
+    const csvRow = { px: '15.25', py: '30.125' } as unknown as FileRow;
+
+    const changes = computeDiff(csvRow, dbRow);
+
+    expect(changes.px).toEqual({ from: null, to: '15.25' });
+    expect(changes.py).toEqual({ from: null, to: '30.125' });
+  });
+
+  it('treats blank px/py cells as "no change", never as a clear', () => {
+    const dbRow = makeDbRow({ StemPlotX: 100.5, StemPlotY: 200.5 });
+    const csvRow = { px: '', py: 'NULL' } as unknown as FileRow;
+
+    const changes = computeDiff(csvRow, dbRow);
+
+    expect(changes.px).toBeUndefined();
+    expect(changes.py).toBeUndefined();
+  });
+
+  it('compares px numerically so trailing decimal zeros are not a change', () => {
+    const dbRow = makeDbRow({ StemPlotX: 100.5 });
+    const csvRow = { px: '100.500000' } as unknown as FileRow;
+
+    expect(computeDiff(csvRow, dbRow).px).toBeUndefined();
+  });
+});

--- a/frontend/app/api/revisionupload/shared/matchdiff.test.ts
+++ b/frontend/app/api/revisionupload/shared/matchdiff.test.ts
@@ -90,4 +90,25 @@ describe('computeDiff plot coordinates', () => {
 
     expect(() => computeDiff(csvRow, dbRow)).toThrow(InvalidFieldValueError);
   });
+
+  it('does not invent a change when the stored value carries more precision than the field is compared at', () => {
+    // MeasuredDBH/LocalX live in DECIMAL(12,6) but canonicalize to 2 places.
+    // Rounding only the CSV side made these look different, so the review UI
+    // showed a change whose `from` and `to` render identically — and applying
+    // it silently rewrote 12.345 to 12.35.
+    const dbRow = makeDbRow({ MeasuredDBH: 12.345, LocalX: 3.456 });
+    const csvRow = { dbh: '12.345', lx: '3.456' } as unknown as FileRow;
+
+    const changes = computeDiff(csvRow, dbRow);
+
+    expect(changes.dbh).toBeUndefined();
+    expect(changes.lx).toBeUndefined();
+  });
+
+  it('still flags a real dbh change at the compared precision', () => {
+    const dbRow = makeDbRow({ MeasuredDBH: 12.345 });
+    const csvRow = { dbh: '13.5' } as unknown as FileRow;
+
+    expect(computeDiff(csvRow, dbRow).dbh).toEqual({ from: '12.345', to: '13.5' });
+  });
 });

--- a/frontend/app/api/revisionupload/shared/matchdiff.ts
+++ b/frontend/app/api/revisionupload/shared/matchdiff.ts
@@ -2,6 +2,7 @@ import type ConnectionManager from '@/lib/db/connectionmanager';
 import { safeFormatQuery } from '@/lib/db/sqlsecurity';
 import { FileRow } from '@/config/macros/formdetails';
 import { canonicalizeRowForHash, RowMode } from '@/config/editplan/canonicalrow';
+import { parseFiniteBase10Number } from '@/config/editplan/fieldpolicy';
 
 export const UPDATABLE_FIELDS = ['dbh', 'hom', 'date', 'codes', 'comments', 'spcode', 'quadrat', 'lx', 'ly', 'px', 'py', 'tag', 'stemtag'] as const;
 
@@ -36,20 +37,21 @@ export type FieldCompareKind = 'numeric' | 'string-ci' | 'numeric-or-string-ci' 
 export interface FieldDescriptor {
   dbProperty: keyof ExistingMeasurementRow;
   compareKind: FieldCompareKind;
+  canonicalProperty?: string;
 }
 
 export const FIELD_DESCRIPTORS: Record<UpdatableField, FieldDescriptor> = {
-  dbh: { dbProperty: 'MeasuredDBH', compareKind: 'numeric' },
-  hom: { dbProperty: 'MeasuredHOM', compareKind: 'numeric' },
+  dbh: { dbProperty: 'MeasuredDBH', compareKind: 'numeric', canonicalProperty: 'MeasuredDBH' },
+  hom: { dbProperty: 'MeasuredHOM', compareKind: 'numeric', canonicalProperty: 'MeasuredHOM' },
   date: { dbProperty: 'MeasurementDate', compareKind: 'date' },
   codes: { dbProperty: 'RawCodes', compareKind: 'string-exact' },
   comments: { dbProperty: 'Description', compareKind: 'string-exact' },
   spcode: { dbProperty: 'SpeciesCode', compareKind: 'string-ci' },
   quadrat: { dbProperty: 'QuadratName', compareKind: 'numeric-or-string-ci' },
-  lx: { dbProperty: 'LocalX', compareKind: 'numeric' },
-  ly: { dbProperty: 'LocalY', compareKind: 'numeric' },
-  px: { dbProperty: 'StemPlotX', compareKind: 'numeric' },
-  py: { dbProperty: 'StemPlotY', compareKind: 'numeric' },
+  lx: { dbProperty: 'LocalX', compareKind: 'numeric', canonicalProperty: 'StemLocalX' },
+  ly: { dbProperty: 'LocalY', compareKind: 'numeric', canonicalProperty: 'StemLocalY' },
+  px: { dbProperty: 'StemPlotX', compareKind: 'numeric', canonicalProperty: 'StemPlotX' },
+  py: { dbProperty: 'StemPlotY', compareKind: 'numeric', canonicalProperty: 'StemPlotY' },
   tag: { dbProperty: 'TreeTag', compareKind: 'numeric-or-string-ci' },
   stemtag: { dbProperty: 'StemTag', compareKind: 'numeric-or-string-ci' }
 };
@@ -112,10 +114,10 @@ export function normalizeDateToString(value: Date | string | null): string | nul
   return String(value).slice(0, 10);
 }
 
-function areEquivalentNumericValues(csvValue: string, dbValue: unknown): boolean {
-  const parsedCsvValue = Number.parseFloat(csvValue);
-  const parsedDbValue = typeof dbValue === 'number' ? dbValue : Number.parseFloat(String(dbValue ?? ''));
-  return Number.isFinite(parsedCsvValue) && Number.isFinite(parsedDbValue) && parsedCsvValue === parsedDbValue;
+function areEquivalentNumericValues(csvValue: unknown, dbValue: unknown): boolean {
+  const parsedCsvValue = parseFiniteBase10Number(csvValue);
+  const parsedDbValue = parseFiniteBase10Number(dbValue);
+  return parsedCsvValue !== null && parsedDbValue !== null && parsedCsvValue === parsedDbValue;
 }
 
 /**
@@ -144,7 +146,7 @@ export function fieldValuesAreEquivalent(compareKind: FieldCompareKind, csvValue
 
   switch (compareKind) {
     case 'numeric':
-      return areEquivalentNumericValues(csvNormalized, dbValue);
+      return areEquivalentNumericValues(csvValue, dbValue);
     case 'date':
       return csvNormalized === dbNormalized;
     case 'string-exact':
@@ -185,8 +187,12 @@ export function computeDiff(csvRow: FileRow, dbRow: ExistingMeasurementRow): Rec
 
     const descriptor = FIELD_DESCRIPTORS[field];
     const dbValue = readDbValueForDisplay(field, dbRow);
+    const comparisonCsvValue =
+      descriptor.compareKind === 'numeric' && descriptor.canonicalProperty
+        ? canonicalizeRowForHash({ [field]: csvValue }, 'revision-update')[descriptor.canonicalProperty]
+        : csvValue;
 
-    if (fieldValuesAreEquivalent(descriptor.compareKind, csvValue, dbValue)) continue;
+    if (fieldValuesAreEquivalent(descriptor.compareKind, comparisonCsvValue, dbValue)) continue;
 
     changes[field] = { from: dbValue, to: csvValue };
   }

--- a/frontend/app/api/revisionupload/shared/matchdiff.ts
+++ b/frontend/app/api/revisionupload/shared/matchdiff.ts
@@ -187,12 +187,18 @@ export function computeDiff(csvRow: FileRow, dbRow: ExistingMeasurementRow): Rec
 
     const descriptor = FIELD_DESCRIPTORS[field];
     const dbValue = readDbValueForDisplay(field, dbRow);
-    const comparisonCsvValue =
-      descriptor.compareKind === 'numeric' && descriptor.canonicalProperty
-        ? canonicalizeRowForHash({ [field]: csvValue }, 'revision-update')[descriptor.canonicalProperty]
-        : csvValue;
+    // Canonicalize BOTH sides at the field's declared precision. Rounding only
+    // the CSV value and comparing it against the raw DECIMAL(12,6) column made
+    // a stored 12.345 differ from a CSV 12.345, surfacing a change whose `from`
+    // and `to` render identically and whose apply silently truncated the row.
+    // Comparing canonical-to-canonical asks the question that actually matters:
+    // would applying this cell change what we store?
+    const canonicalize = (value: unknown) => canonicalizeRowForHash({ [field]: value }, 'revision-update')[descriptor.canonicalProperty as string];
+    const isCanonicalNumeric = descriptor.compareKind === 'numeric' && descriptor.canonicalProperty !== undefined;
+    const comparisonCsvValue = isCanonicalNumeric ? canonicalize(csvValue) : csvValue;
+    const comparisonDbValue = isCanonicalNumeric ? canonicalize(dbValue) : dbValue;
 
-    if (fieldValuesAreEquivalent(descriptor.compareKind, comparisonCsvValue, dbValue)) continue;
+    if (fieldValuesAreEquivalent(descriptor.compareKind, comparisonCsvValue, comparisonDbValue)) continue;
 
     changes[field] = { from: dbValue, to: csvValue };
   }

--- a/frontend/app/api/revisionupload/shared/matchdiff.ts
+++ b/frontend/app/api/revisionupload/shared/matchdiff.ts
@@ -3,7 +3,7 @@ import { safeFormatQuery } from '@/lib/db/sqlsecurity';
 import { FileRow } from '@/config/macros/formdetails';
 import { canonicalizeRowForHash, RowMode } from '@/config/editplan/canonicalrow';
 
-export const UPDATABLE_FIELDS = ['dbh', 'hom', 'date', 'codes', 'comments', 'spcode', 'quadrat', 'lx', 'ly', 'tag', 'stemtag'] as const;
+export const UPDATABLE_FIELDS = ['dbh', 'hom', 'date', 'codes', 'comments', 'spcode', 'quadrat', 'lx', 'ly', 'px', 'py', 'tag', 'stemtag'] as const;
 
 export type UpdatableField = (typeof UPDATABLE_FIELDS)[number];
 export type MatchStrategy = 'stemid' | 'tag_stemtag';
@@ -48,6 +48,8 @@ export const FIELD_DESCRIPTORS: Record<UpdatableField, FieldDescriptor> = {
   quadrat: { dbProperty: 'QuadratName', compareKind: 'numeric-or-string-ci' },
   lx: { dbProperty: 'LocalX', compareKind: 'numeric' },
   ly: { dbProperty: 'LocalY', compareKind: 'numeric' },
+  px: { dbProperty: 'StemPlotX', compareKind: 'numeric' },
+  py: { dbProperty: 'StemPlotY', compareKind: 'numeric' },
   tag: { dbProperty: 'TreeTag', compareKind: 'numeric-or-string-ci' },
   stemtag: { dbProperty: 'StemTag', compareKind: 'numeric-or-string-ci' }
 };
@@ -73,6 +75,8 @@ export interface ExistingMeasurementRow {
   QuadratName: string | null;
   LocalX: number | string | null;
   LocalY: number | string | null;
+  StemPlotX: number | string | null;
+  StemPlotY: number | string | null;
 }
 
 export const LOOKUP_CHUNK_SIZE = 1000;
@@ -82,7 +86,8 @@ const MEASUREMENT_SELECT = `cm.CoreMeasurementID, cm.StemGUID, cm.IsActive, cm.M
               cm.MeasurementDate, cm.RawCodes, cm.Description, cm.RawTreeTag, cm.RawStemTag,
               st.IsActive AS StemIsActive, t.IsActive AS TreeIsActive, q.IsActive AS QuadratIsActive,
               q.PlotID, t.TreeTag, st.StemTag,
-              sp.SpeciesCode, q.QuadratName, st.LocalX, st.LocalY`;
+              sp.SpeciesCode, q.QuadratName, st.LocalX, st.LocalY,
+              COALESCE(cm.RawPlotX, st.PlotX) AS StemPlotX, COALESCE(cm.RawPlotY, st.PlotY) AS StemPlotY`;
 
 const MEASUREMENT_JOINS = `??.coremeasurements cm
        LEFT JOIN ??.stems st ON st.StemGUID = cm.StemGUID

--- a/frontend/app/api/setupbulkfailure/[fileID]/[batchID]/route.ts
+++ b/frontend/app/api/setupbulkfailure/[fileID]/[batchID]/route.ts
@@ -3,6 +3,7 @@ import { HTTPResponses } from '@/config/macros';
 import ConnectionManager from '@/lib/db/connectionmanager';
 import { validateSchemaOrThrow } from '@/lib/db/sqlsecurity';
 import ailogger from '@/ailogger';
+import { toError } from '@/lib/errorhelpers';
 import { moveTemporaryBatchToFailedMeasurements, moveTemporarySubBatchesToFailedMeasurements } from '@/lib/batchfailuretransfer';
 import { requireUploadSessionOwnership, UploadSessionOwnershipError, UploadSessionState } from '@/config/uploadsessiontracker';
 import { fromQuery, withRouteAuthz, type RouteContext } from '@/lib/route-authz';
@@ -86,7 +87,7 @@ async function handler(request: NextRequest, context: RouteContext) {
       await connectionManager.closeConnection();
     } catch (closeError) {
       if (operationError === undefined) throw closeError;
-      ailogger.error(`Failed to close failure-transfer connection for ${fileID}-${batchID}:`, closeError);
+      ailogger.error(`Failed to close failure-transfer connection for ${fileID}-${batchID}:`, toError(closeError));
     }
   }
   return new NextResponse(JSON.stringify({ temp: true }), { status: HTTPResponses.OK });

--- a/frontend/app/api/setupbulkfailure/[fileID]/[batchID]/route.ts
+++ b/frontend/app/api/setupbulkfailure/[fileID]/[batchID]/route.ts
@@ -62,11 +62,11 @@ async function handler(request: NextRequest, context: RouteContext) {
 
     // After sub-batching, remaining rows may have sub-batch IDs (e.g. batchID__sub001).
     // Try exact match first, then fall back to moving all sub-batches for this file.
-    let movedRows = await moveTemporaryBatchToFailedMeasurements(connectionManager, schema, fileID, batchID, failureReason);
+    let movedRows = await moveTemporaryBatchToFailedMeasurements(connectionManager, schema, fileID, batchID, failureReason, 'sql_exception');
 
     if (movedRows === 0) {
       const subBatchPrefix = `${batchID}__sub`;
-      movedRows = await moveTemporarySubBatchesToFailedMeasurements(connectionManager, schema, fileID, subBatchPrefix, failureReason);
+      movedRows = await moveTemporarySubBatchesToFailedMeasurements(connectionManager, schema, fileID, subBatchPrefix, failureReason, 'sql_exception');
       if (movedRows > 0) {
         ailogger.warn(
           `Moved ${movedRows} sub-batched temporary rows to unresolved coremeasurements for ${fileID} (prefix: ${subBatchPrefix}). Reason: ${failureReason}`

--- a/frontend/app/api/setupbulkfailure/[fileID]/[batchID]/route.ts
+++ b/frontend/app/api/setupbulkfailure/[fileID]/[batchID]/route.ts
@@ -8,6 +8,7 @@ import { moveTemporaryBatchToFailedMeasurements, moveTemporarySubBatchesToFailed
 import { requireUploadSessionOwnership, UploadSessionOwnershipError, UploadSessionState } from '@/config/uploadsessiontracker';
 import { fromQuery, withRouteAuthz, type RouteContext } from '@/lib/route-authz';
 import { BatchFamilyScopeError, discoverBatchFamily } from '@/lib/uploads/batch-family';
+import { inferSystemFailureKind } from '@/config/measurementerrors';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
@@ -54,12 +55,17 @@ async function handler(request: NextRequest, context: RouteContext) {
       });
     }
 
+    // The client reports whatever killed its setupbulkprocedure request as free
+    // text. A transport failure (front-end 504, aborted fetch) means these rows
+    // were never judged, so they must not be recorded as ingestion SQL errors.
+    const failureKind = inferSystemFailureKind(failureReason);
+
     // After sub-batching, remaining rows may have sub-batch IDs (e.g. batchID__sub001).
     // Try exact match first, then fall back to moving all sub-batches for this file.
-    let movedRows = await moveTemporaryBatchToFailedMeasurements(connectionManager, schema, fileID, batchID, failureReason, 'sql_exception');
+    let movedRows = await moveTemporaryBatchToFailedMeasurements(connectionManager, schema, fileID, batchID, failureReason, failureKind);
 
     if (movedRows === 0) {
-      movedRows = await moveTemporarySubBatchesToFailedMeasurements(connectionManager, schema, fileID, batchID, failureReason, 'sql_exception');
+      movedRows = await moveTemporarySubBatchesToFailedMeasurements(connectionManager, schema, fileID, batchID, failureReason, failureKind);
       if (movedRows > 0) {
         ailogger.warn(`Moved ${movedRows} sub-batched temporary rows to unresolved coremeasurements for ${fileID}-${batchID}. Reason: ${failureReason}`);
       }

--- a/frontend/app/api/setupbulkfailure/[fileID]/[batchID]/route.ts
+++ b/frontend/app/api/setupbulkfailure/[fileID]/[batchID]/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { HTTPResponses } from '@/config/macros';
 import ConnectionManager from '@/lib/db/connectionmanager';
-import { safeFormatQuery, validateSchemaOrThrow } from '@/lib/db/sqlsecurity';
+import { validateSchemaOrThrow } from '@/lib/db/sqlsecurity';
 import ailogger from '@/ailogger';
 import { moveTemporaryBatchToFailedMeasurements, moveTemporarySubBatchesToFailedMeasurements } from '@/lib/batchfailuretransfer';
 import { requireUploadSessionOwnership, UploadSessionOwnershipError, UploadSessionState } from '@/config/uploadsessiontracker';
 import { fromQuery, withRouteAuthz, type RouteContext } from '@/lib/route-authz';
+import { BatchFamilyScopeError, discoverBatchFamily } from '@/lib/uploads/batch-family';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
@@ -38,23 +39,15 @@ async function handler(request: NextRequest, context: RouteContext) {
   }
 
   const connectionManager = ConnectionManager.getInstance();
+  let operationError: unknown;
   try {
-    const scopeSQL = safeFormatQuery(
-      schema,
-      `SELECT PlotID, CensusID
-       FROM ??.temporarymeasurements
-       WHERE FileID = ?
-         AND (BatchID = ? OR BatchID LIKE ?)
-       GROUP BY PlotID, CensusID
-       LIMIT 1`
-    );
-    const scopeRows = await connectionManager.executeQuery(scopeSQL, [fileID, batchID, `${batchID}__sub%`]);
-    if (Array.isArray(scopeRows) && scopeRows.length > 0) {
+    const family = await discoverBatchFamily((sql, params) => connectionManager.executeQuery(sql, params), schema, fileID, batchID);
+    if (family) {
       await requireUploadSessionOwnership({
         schema,
         sessionId,
-        plotId: Number(scopeRows[0].PlotID),
-        censusId: Number(scopeRows[0].CensusID),
+        plotId: family.plotID,
+        censusId: family.censusID,
         allowedStates: [UploadSessionState.PROCESSING, UploadSessionState.COLLAPSING],
         contextLabel: `batch failure handling for ${fileID}-${batchID}`
       });
@@ -65,19 +58,20 @@ async function handler(request: NextRequest, context: RouteContext) {
     let movedRows = await moveTemporaryBatchToFailedMeasurements(connectionManager, schema, fileID, batchID, failureReason, 'sql_exception');
 
     if (movedRows === 0) {
-      const subBatchPrefix = `${batchID}__sub`;
-      movedRows = await moveTemporarySubBatchesToFailedMeasurements(connectionManager, schema, fileID, subBatchPrefix, failureReason, 'sql_exception');
+      movedRows = await moveTemporarySubBatchesToFailedMeasurements(connectionManager, schema, fileID, batchID, failureReason, 'sql_exception');
       if (movedRows > 0) {
-        ailogger.warn(
-          `Moved ${movedRows} sub-batched temporary rows to unresolved coremeasurements for ${fileID} (prefix: ${subBatchPrefix}). Reason: ${failureReason}`
-        );
+        ailogger.warn(`Moved ${movedRows} sub-batched temporary rows to unresolved coremeasurements for ${fileID}-${batchID}. Reason: ${failureReason}`);
       }
     } else {
       ailogger.warn(`Moved ${movedRows} temporary rows to unresolved coremeasurements for ${fileID}-${batchID}. Reason: ${failureReason}`);
     }
   } catch (error: any) {
+    operationError = error;
     if (error instanceof UploadSessionOwnershipError) {
       return new NextResponse(JSON.stringify({ error: error.message }), { status: error.status });
+    }
+    if (error instanceof BatchFamilyScopeError) {
+      return new NextResponse(JSON.stringify({ error: error.message }), { status: HTTPResponses.CONFLICT });
     }
     ailogger.error(`failure transfer for ${fileID}-${batchID}:`, error);
     return new NextResponse(
@@ -88,7 +82,12 @@ async function handler(request: NextRequest, context: RouteContext) {
       { status: HTTPResponses.INTERNAL_SERVER_ERROR }
     );
   } finally {
-    await connectionManager.closeConnection();
+    try {
+      await connectionManager.closeConnection();
+    } catch (closeError) {
+      if (operationError === undefined) throw closeError;
+      ailogger.error(`Failed to close failure-transfer connection for ${fileID}-${batchID}:`, closeError);
+    }
   }
   return new NextResponse(JSON.stringify({ temp: true }), { status: HTTPResponses.OK });
 }

--- a/frontend/components/client/datagridcolumns.test.tsx
+++ b/frontend/components/client/datagridcolumns.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { ViewFullTableGridColumns, VIEW_FULL_TABLE_COLUMN_WIDTHS } from './datagridcolumns';
+import { MeasurementsSummaryViewGridColumns, ViewFullTableGridColumns, VIEW_FULL_TABLE_COLUMN_WIDTHS } from './datagridcolumns';
 
 // The archive "All Historical Data" grid formerly gave every one of its columns a
 // uniform `flex: 0.3` with no minWidth, which starved headers down to one or two visible
@@ -62,5 +62,18 @@ describe('ViewFullTableGridColumns width presets', () => {
     // code bucket (includes the hidden-by-default ID columns).
     expect(byField.get('speciesCode')).toMatchObject(VIEW_FULL_TABLE_COLUMN_WIDTHS.code);
     expect(byField.get('coreMeasurementID')).toMatchObject(VIEW_FULL_TABLE_COLUMN_WIDTHS.code);
+  });
+});
+
+describe('MeasurementsSummaryViewGridColumns plot coordinates', () => {
+  it.each(['stemPlotX', 'stemPlotY'])('renders missing %s as blank while preserving a real zero', field => {
+    const column = MeasurementsSummaryViewGridColumns.find(candidate => candidate.field === field);
+    expect(column?.valueFormatter).toBeTypeOf('function');
+    const format = column!.valueFormatter as (value: number | null | undefined) => string;
+
+    expect(format(null)).toBe('');
+    expect(format(undefined)).toBe('');
+    expect(format(0)).toBe('0.00');
+    expect(format(12.345)).toBe('12.35');
   });
 });

--- a/frontend/components/client/datagridcolumns.tsx
+++ b/frontend/components/client/datagridcolumns.tsx
@@ -706,9 +706,10 @@ export const MeasurementsSummaryViewGridColumns: GridColDef[] = standardizeGridC
       return value == null ? '' : Number(value).toFixed(2);
     },
     maxWidth: 100,
-    editable: false,
+    editable: true,
     type: 'number',
-    filterOperators: customNumericOperators
+    filterOperators: customNumericOperators,
+    preProcessEditCellProps: params => preprocessor(params)
   },
   {
     field: 'stemPlotY',
@@ -720,8 +721,9 @@ export const MeasurementsSummaryViewGridColumns: GridColDef[] = standardizeGridC
     valueFormatter: (value: number | null | undefined) => {
       return value == null ? '' : Number(value).toFixed(2);
     },
-    editable: false,
-    filterOperators: customNumericOperators
+    editable: true,
+    filterOperators: customNumericOperators,
+    preProcessEditCellProps: params => preprocessor(params)
   },
   {
     field: 'measuredDBH',

--- a/frontend/components/client/datagridcolumns.tsx
+++ b/frontend/components/client/datagridcolumns.tsx
@@ -703,7 +703,7 @@ export const MeasurementsSummaryViewGridColumns: GridColDef[] = standardizeGridC
     renderHeader: () => formatHeader('X', 'Plot'),
     flex: 0.7,
     valueFormatter: (value: number | null | undefined) => {
-      return Number(value ?? 0).toFixed(2);
+      return value == null ? '' : Number(value).toFixed(2);
     },
     maxWidth: 100,
     editable: false,
@@ -718,7 +718,7 @@ export const MeasurementsSummaryViewGridColumns: GridColDef[] = standardizeGridC
     type: 'number',
     maxWidth: 100,
     valueFormatter: (value: number | null | undefined) => {
-      return Number(value ?? 0).toFixed(2);
+      return value == null ? '' : Number(value).toFixed(2);
     },
     editable: false,
     filterOperators: customNumericOperators

--- a/frontend/components/uploadsystem/segments/uploadfiresql.tsx
+++ b/frontend/components/uploadsystem/segments/uploadfiresql.tsx
@@ -446,7 +446,7 @@ const UploadFireSQL: React.FC<UploadFireProps> = ({
         date: row.date ? moment(row.date).format('YYYY-MM-DD') : null,
         codes: row.codes || null,
         comments: row.comments || null,
-        failureReasons: row.failureReason || 'Unknown error'
+        failureReasons: row.failureReason || undefined
       }));
 
       const response = await fetchWithTimeout(
@@ -1065,7 +1065,7 @@ const UploadFireSQL: React.FC<UploadFireProps> = ({
                     } else {
                       parsingInvalidRows.push({
                         ...row,
-                        failureReason: verdict.failureReason ?? 'Unknown error',
+                        failureReason: verdict.failureReason ?? null,
                         ...(verdict.hasExtraColumns ? { excessData: row['__parsed_extra'] } : {})
                       });
                     }

--- a/frontend/components/uploadsystem/segments/uploadrevisionmatch.tsx
+++ b/frontend/components/uploadsystem/segments/uploadrevisionmatch.tsx
@@ -27,7 +27,7 @@ interface UploadRevisionMatchProps {
 
 const NEW_ROW_DISPLAY_FIELDS = ['tag', 'stemtag', 'spcode', 'quadrat', 'dbh', 'date'] as const;
 
-const IDENTITY_FIELDS: ReadonlySet<string> = new Set(['spcode', 'tag', 'stemtag', 'quadrat', 'lx', 'ly']);
+const IDENTITY_FIELDS: ReadonlySet<string> = new Set(['spcode', 'tag', 'stemtag', 'quadrat', 'lx', 'ly', 'px', 'py']);
 
 function formatValue(value: unknown): string {
   if (value === null || value === undefined) return '—';
@@ -171,7 +171,7 @@ export default function UploadRevisionMatch(props: Readonly<UploadRevisionMatchP
           <Stack spacing={0.5}>
             <Typography level="body-sm" fontWeight="lg">
               {rowsWithIdentityChanges.length} {rowsWithIdentityChanges.length === 1 ? 'row edits' : 'rows edit'} identity columns (<code>spcode</code>,{' '}
-              <code>tag</code>, <code>stemtag</code>, <code>quadrat</code>, <code>lx</code>, <code>ly</code>).
+              <code>tag</code>, <code>stemtag</code>, <code>quadrat</code>, <code>lx</code>, <code>ly</code>, <code>px</code>, <code>py</code>).
             </Typography>
             <Typography level="body-sm">
               These edits will be applied to the matched rows and may propagate to other measurements that share the same tree, stem, or quadrat. Review the

--- a/frontend/config/datagridhelpers.ts
+++ b/frontend/config/datagridhelpers.ts
@@ -336,6 +336,11 @@ export const failureErrorMapping: Record<string, string[]> = {
   'Quadrat mismatch across censuses': ['quadrat'],
   'Coordinate drift': ['x', 'y'],
   'Coordinate drift exceeds allowed threshold': ['x', 'y'],
+  'Coordinate value is outside the accepted or storable range': ['x', 'y'],
+  // Legacy key: matches catalog text on schemas whose INVALID_COORDINATE row hasn't
+  // yet been lazily refreshed by ensureMeasurementErrorDefinition's ON DUPLICATE KEY
+  // UPDATE. Keep until every live schema has ingested at least one coordinate reject
+  // under the corrected wording.
   'Coordinate value is negative': ['x', 'y'],
   'DBH must be non-negative': ['dbh'],
   'HOM must be non-negative': ['hom'],

--- a/frontend/config/editplan/analyzer.ts
+++ b/frontend/config/editplan/analyzer.ts
@@ -285,6 +285,8 @@ async function loadCurrentRow(
          s.StemGUID,
          s.LocalX AS StemLocalX,
          s.LocalY AS StemLocalY,
+         COALESCE(cm.RawPlotX, s.PlotX) AS StemPlotX,
+         COALESCE(cm.RawPlotY, s.PlotY) AS StemPlotY,
          q.QuadratName
        FROM ??.coremeasurements cm
        JOIN ??.census c ON c.CensusID = cm.CensusID

--- a/frontend/config/editplan/canonicalrow.test.ts
+++ b/frontend/config/editplan/canonicalrow.test.ts
@@ -127,7 +127,14 @@ describe('canonicalizeRowForHash', () => {
 
     it('rejects malformed numeric strings instead of converting them to null', () => {
       expect(() => canonicalizeRowForHash({ dbh: '12abc' }, 'revision-update')).toThrow(InvalidFieldValueError);
+      expect(() => canonicalizeRowForHash({ px: '0x10' }, 'revision-update')).toThrow(InvalidFieldValueError);
       expect(() => canonicalizeRowForHash({ hom: Number.NaN }, 'revision-update')).toThrow(InvalidFieldValueError);
+    });
+
+    it('rejects plot coordinates outside DECIMAL(12,6) while accepting the boundary', () => {
+      expect(canonicalizeRowForHash({ px: '999999.999999' }, 'revision-update')).toMatchObject({ StemPlotX: 999999.999999 });
+      expect(() => canonicalizeRowForHash({ px: '1000000' }, 'revision-update')).toThrow(InvalidFieldValueError);
+      expect(() => canonicalizeRowForHash({ py: '-1000000' }, 'revision-insert')).toThrow(InvalidFieldValueError);
     });
 
     it('accepts numeric values directly without string conversion', () => {

--- a/frontend/config/editplan/canonicalrow.test.ts
+++ b/frontend/config/editplan/canonicalrow.test.ts
@@ -19,6 +19,12 @@ describe('canonicalizeRowForHash', () => {
       expect(out.StemLocalX).toBe(3.14);
       expect(out.StemLocalY).toBe(2.72);
     });
+
+    it('maps px/py to plot coordinates at DECIMAL(12,6) precision, preserving sign', () => {
+      const out = canonicalizeRowForHash({ px: '-2.5312449', py: '487.125' }, 'revision-update');
+      expect(out.StemPlotX).toBe(-2.531245); // precision-6 rounds the 7th decimal
+      expect(out.StemPlotY).toBe(487.125);
+    });
   });
 
   describe('revision-insert mode', () => {

--- a/frontend/config/editplan/canonicalrow.ts
+++ b/frontend/config/editplan/canonicalrow.ts
@@ -1,4 +1,4 @@
-import { InvalidFieldValueError, PER_COLUMN_DECIMAL_PRECISION, isDateField } from './fieldpolicy';
+import { InvalidFieldValueError, PER_COLUMN_DECIMAL_PRECISION, isDateField, normalizeNumericValue } from './fieldpolicy';
 
 export type RowMode = 'revision-update' | 'revision-insert';
 
@@ -90,18 +90,9 @@ function normalizeDate(value: unknown): string | null {
 }
 
 function normalizeDecimal(field: string, value: unknown, precision: number): number | null {
-  if (typeof value === 'number') {
-    if (!Number.isFinite(value)) {
-      throw new InvalidFieldValueError(field, value, `Field "${field}" must be a finite number`);
-    }
-    return Number(value.toFixed(precision));
-  }
-  const trimmed = normalizeString(value);
-  if (trimmed === null) return null;
-  const parsed = Number(trimmed);
-  if (!Number.isFinite(parsed)) {
-    throw new InvalidFieldValueError(field, value, `Field "${field}" must be a finite number`);
-  }
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string' && normalizeString(value) === null) return null;
+  const parsed = normalizeNumericValue(field, value);
   return Number(parsed.toFixed(precision));
 }
 

--- a/frontend/config/editplan/canonicalrow.ts
+++ b/frontend/config/editplan/canonicalrow.ts
@@ -9,6 +9,8 @@ type CanonicalField =
   | 'QuadratName'
   | 'StemLocalX'
   | 'StemLocalY'
+  | 'StemPlotX'
+  | 'StemPlotY'
   | 'MeasuredDBH'
   | 'MeasuredHOM'
   | 'MeasurementDate'
@@ -26,7 +28,9 @@ const UPDATE_FIELDS: readonly CanonicalField[] = [
   'SpeciesCode',
   'QuadratName',
   'StemLocalX',
-  'StemLocalY'
+  'StemLocalY',
+  'StemPlotX',
+  'StemPlotY'
 ];
 
 const INSERT_FIELDS: readonly CanonicalField[] = [...UPDATE_FIELDS];
@@ -42,6 +46,8 @@ const CSV_ALIAS_TO_CANONICAL: Record<string, CanonicalField> = {
   quadrat: 'QuadratName',
   lx: 'StemLocalX',
   ly: 'StemLocalY',
+  px: 'StemPlotX',
+  py: 'StemPlotY',
   dbh: 'MeasuredDBH',
   hom: 'MeasuredHOM',
   date: 'MeasurementDate',

--- a/frontend/config/editplan/fieldpolicy.test.ts
+++ b/frontend/config/editplan/fieldpolicy.test.ts
@@ -55,8 +55,9 @@ describe('fieldpolicy', () => {
       expect(normalizeFieldValue('StemLocalX', '-5.5')).toBe(-5.5);
     });
 
-    it('rejects malformed numeric strings before the writer can coerce them to null', () => {
+    it('rejects malformed and non-base-10 numeric strings before the writer can coerce them', () => {
       expect(() => normalizeFieldValue('MeasuredDBH', 'abc')).toThrow(InvalidFieldValueError);
+      expect(() => normalizeFieldValue('StemPlotX', '0x10')).toThrow(InvalidFieldValueError);
       expect(() => normalizeFieldValue('StemLocalY', Number.NaN)).toThrow(InvalidFieldValueError);
     });
 
@@ -189,9 +190,10 @@ describe('fieldpolicy', () => {
       expect(normalizeFieldValue('MeasuredHOM', -0.1)).toBe(-0.1);
     });
 
-    it('passes through extreme finite coordinates unchanged — analyzer does not clamp StemLocalX/Y', () => {
-      expect(normalizeFieldValue('StemLocalX', GIANT_COORDINATE)).toBe(GIANT_COORDINATE);
-      expect(normalizeFieldValue('StemLocalY', -GIANT_COORDINATE)).toBe(-GIANT_COORDINATE);
+    it('rejects finite coordinates outside the DECIMAL(12,6) storage range', () => {
+      expect(() => normalizeFieldValue('StemLocalX', GIANT_COORDINATE)).toThrow(InvalidFieldValueError);
+      expect(() => normalizeFieldValue('StemLocalY', -GIANT_COORDINATE)).toThrow(InvalidFieldValueError);
+      expect(normalizeFieldValue('StemPlotX', '999999.999999')).toBe(999999.999999);
     });
 
     it('treats tab-only content as empty whitespace for invalid-clear fields', () => {

--- a/frontend/config/editplan/fieldpolicy.ts
+++ b/frontend/config/editplan/fieldpolicy.ts
@@ -158,6 +158,22 @@ export class InvalidFieldValueError extends Error {
   }
 }
 
+// Every numeric edit-plan field currently persists to a DECIMAL(12,6)
+// column. Keep parsing and representable-range validation at the API boundary
+// so MySQL never has to coerce an out-of-range value in a permissive staging
+// or deployment environment.
+export const MAX_STORED_DECIMAL = 999999.999999;
+export const BASE_10_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+
+export function parseFiniteBase10Number(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (trimmed === '' || !BASE_10_NUMBER_PATTERN.test(trimmed)) return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 const TAXONOMIC_IDENTITY_FIELDS = new Set(['SpeciesCode', 'SpCode', 'spcode']);
 const SPECIES_EDIT_ROLES = new Set<UserAuthRoles>(['global', 'db admin']);
 
@@ -167,10 +183,13 @@ export function isFieldEditableByRole(fieldName: string, role: UserAuthRoles | n
   return role !== null && role !== undefined && SPECIES_EDIT_ROLES.has(role);
 }
 
-function normalizeNumericValue(field: string, value: unknown): number {
-  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
-  if (!Number.isFinite(parsed)) {
+export function normalizeNumericValue(field: string, value: unknown): number {
+  const parsed = parseFiniteBase10Number(value);
+  if (parsed === null) {
     throw new InvalidFieldValueError(field, value, `Field "${field}" must be a finite number`);
+  }
+  if (Math.abs(parsed) > MAX_STORED_DECIMAL) {
+    throw new InvalidFieldValueError(field, value, `Field "${field}" must be between -${MAX_STORED_DECIMAL} and ${MAX_STORED_DECIMAL}`);
   }
   return parsed;
 }

--- a/frontend/config/editplan/fieldpolicy.ts
+++ b/frontend/config/editplan/fieldpolicy.ts
@@ -10,6 +10,8 @@ export const EDITABLE_FIELDS_BY_SURFACE: Record<EditSurface, ReadonlySet<string>
     'QuadratName',
     'StemLocalX',
     'StemLocalY',
+    'StemPlotX',
+    'StemPlotY',
     'MeasurementDate',
     'MeasuredDBH',
     'MeasuredHOM',
@@ -18,7 +20,7 @@ export const EDITABLE_FIELDS_BY_SURFACE: Record<EditSurface, ReadonlySet<string>
   ]),
   failedmeasurements: new Set(['Tag', 'StemTag', 'SpCode', 'Quadrat', 'X', 'Y', 'DBH', 'HOM', 'Date', 'Codes', 'Comments']),
   'revision-row-local': new Set(['dbh', 'hom', 'date', 'codes', 'comments']),
-  'revision-identity': new Set(['spcode', 'tag', 'stemtag', 'quadrat', 'lx', 'ly', 'dbh', 'hom', 'date', 'codes', 'comments'])
+  'revision-identity': new Set(['spcode', 'tag', 'stemtag', 'quadrat', 'lx', 'ly', 'px', 'py', 'dbh', 'hom', 'date', 'codes', 'comments'])
 };
 
 export const FIELD_ALIASES_BY_SURFACE: Record<EditSurface, Record<string, string>> = {
@@ -29,6 +31,8 @@ export const FIELD_ALIASES_BY_SURFACE: Record<EditSurface, Record<string, string
     quadratName: 'QuadratName',
     stemLocalX: 'StemLocalX',
     stemLocalY: 'StemLocalY',
+    stemPlotX: 'StemPlotX',
+    stemPlotY: 'StemPlotY',
     measurementDate: 'MeasurementDate',
     measuredDBH: 'MeasuredDBH',
     measuredHOM: 'MeasuredHOM',
@@ -105,6 +109,8 @@ export const CLEAR_POLICY: Record<string, ClearSemantics> = {
   MeasuredHOM: 'no-op-on-blank',
   StemLocalX: 'no-op-on-blank',
   StemLocalY: 'no-op-on-blank',
+  StemPlotX: 'no-op-on-blank',
+  StemPlotY: 'no-op-on-blank',
   MeasurementDate: 'invalid-clear',
   Description: 'clear-on-blank',
   Attributes: 'clear-on-blank'
@@ -115,6 +121,10 @@ export const PER_COLUMN_DECIMAL_PRECISION: Record<string, number> = {
   MeasuredHOM: 2,
   StemLocalX: 2,
   StemLocalY: 2,
+  // Plot coordinates persist in DECIMAL(12,6) columns; keep the full stored
+  // scale so diff/hash normalization never flags an unchanged 6-decimal value.
+  StemPlotX: 6,
+  StemPlotY: 6,
   DBH: 2,
   HOM: 2,
   X: 2,

--- a/frontend/config/editplan/rules/coordinates.test.ts
+++ b/frontend/config/editplan/rules/coordinates.test.ts
@@ -40,6 +40,31 @@ describe('applyCoordinateRules', () => {
     expect(effects[0].references?.stemGUIDs).toEqual([STEM_GUID]);
   });
 
+  it('emits R4 when only StemPlotX changed', async () => {
+    const ctx = makeCtx({
+      newRow: { StemPlotX: -3.25 },
+      changedFields: new Set(['StemPlotX'])
+    });
+    const effects = await applyCoordinateRules(ctx);
+    expect(effects).toHaveLength(1);
+    expect(effects[0].id).toBe('R4');
+    expect(effects[0].severity).toBe('warn');
+    expect(effects[0].affectedTable).toBe('stems');
+    expect(effects[0].affectedRowCount).toBe(SHARED_COUNT);
+    expect(effects[0].references?.stemGUIDs).toEqual([STEM_GUID]);
+  });
+
+  it('emits R4 when only StemPlotY changed', async () => {
+    const ctx = makeCtx({
+      newRow: { StemPlotY: 512.4 },
+      changedFields: new Set(['StemPlotY'])
+    });
+    const effects = await applyCoordinateRules(ctx);
+    expect(effects).toHaveLength(1);
+    expect(effects[0].id).toBe('R4');
+    expect(effects[0].affectedRowCount).toBe(SHARED_COUNT);
+  });
+
   it('emits R4 when only StemLocalY changed', async () => {
     const ctx = makeCtx({
       newRow: { StemLocalY: 99.0 },

--- a/frontend/config/editplan/rules/coordinates.test.ts
+++ b/frontend/config/editplan/rules/coordinates.test.ts
@@ -38,6 +38,7 @@ describe('applyCoordinateRules', () => {
     expect(effects[0].affectedTable).toBe('stems');
     expect(effects[0].affectedRowCount).toBe(SHARED_COUNT);
     expect(effects[0].references?.stemGUIDs).toEqual([STEM_GUID]);
+    expect(effects[0].detail).toContain('every measurement referencing that stem reflects the new value');
   });
 
   it('emits R4 when only StemPlotX changed', async () => {
@@ -52,6 +53,9 @@ describe('applyCoordinateRules', () => {
     expect(effects[0].affectedTable).toBe('stems');
     expect(effects[0].affectedRowCount).toBe(SHARED_COUNT);
     expect(effects[0].references?.stemGUIDs).toEqual([STEM_GUID]);
+    expect(effects[0].title).toContain('Shared stem plot coordinate');
+    expect(effects[0].detail).toContain('raw upload values keep displaying those snapshots');
+    expect(effects[0].detail).not.toContain('every measurement referencing that stem reflects the new value');
   });
 
   it('emits R4 when only StemPlotY changed', async () => {

--- a/frontend/config/editplan/rules/coordinates.ts
+++ b/frontend/config/editplan/rules/coordinates.ts
@@ -3,7 +3,8 @@ import { RuleContext } from './context';
 import { safeFormatQuery } from '@/lib/db/sqlsecurity';
 
 export async function applyCoordinateRules(ctx: RuleContext): Promise<Effect[]> {
-  if (!ctx.changedFields.has('StemLocalX') && !ctx.changedFields.has('StemLocalY')) return [];
+  const coordinateFields = ['StemLocalX', 'StemLocalY', 'StemPlotX', 'StemPlotY'];
+  if (!coordinateFields.some(field => ctx.changedFields.has(field))) return [];
   const stemGUID = Number(ctx.oldRow.StemGUID);
   if (!stemGUID) return [];
   const rows = await ctx.cm.executeQuery(

--- a/frontend/config/editplan/rules/coordinates.ts
+++ b/frontend/config/editplan/rules/coordinates.ts
@@ -5,6 +5,7 @@ import { safeFormatQuery } from '@/lib/db/sqlsecurity';
 export async function applyCoordinateRules(ctx: RuleContext): Promise<Effect[]> {
   const coordinateFields = ['StemLocalX', 'StemLocalY', 'StemPlotX', 'StemPlotY'];
   if (!coordinateFields.some(field => ctx.changedFields.has(field))) return [];
+  const includesPlotCoordinate = ctx.changedFields.has('StemPlotX') || ctx.changedFields.has('StemPlotY');
   const stemGUID = Number(ctx.oldRow.StemGUID);
   if (!stemGUID) return [];
   const rows = await ctx.cm.executeQuery(
@@ -18,8 +19,12 @@ export async function applyCoordinateRules(ctx: RuleContext): Promise<Effect[]> 
       id: 'R4',
       severity: 'warn',
       category: 'cross-row',
-      title: `Stem coordinate will propagate to ${count} measurement(s)`,
-      detail: `Stem S#${stemGUID} coordinate change updates the stem row; every measurement referencing that stem reflects the new value.`,
+      title: includesPlotCoordinate
+        ? `Shared stem plot coordinate affects ${count} measurement(s)`
+        : `Stem coordinate will propagate to ${count} measurement(s)`,
+      detail: includesPlotCoordinate
+        ? `Stem S#${stemGUID} plot-coordinate change updates the shared stem row. Measurements without their own raw plot-coordinate snapshot reflect the new canonical value; measurements with raw upload values keep displaying those snapshots.`
+        : `Stem S#${stemGUID} coordinate change updates the stem row; every measurement referencing that stem reflects the new value.`,
       affectedTable: 'stems',
       affectedRowCount: count,
       references: { stemGUIDs: [stemGUID] }

--- a/frontend/config/editplan/writers/failedmeasurements.ts
+++ b/frontend/config/editplan/writers/failedmeasurements.ts
@@ -101,10 +101,14 @@ export async function writeFailedMeasurements(cm: ConnectionManager, input: Appl
   const resolvedCodes = pickCanonical(changedFields, newValues, beforeRow, 'Codes', 'RawCodes', toOptionalString);
   const resolvedComments = pickCanonical(changedFields, newValues, beforeRow, 'Comments', 'RawComments', toOptionalString);
 
-  // Description mirrors RawComments on write (legacy PATCH passed Comments twice:
-  // once for RawComments, once for Description). Revalidation may overwrite it
-  // below with concatenated error messages.
-  const initialDescription = resolvedComments;
+  // Description is the reject-reason column, never a second copy of the user's
+  // comments — the legacy PATCH passed Comments twice (once for RawComments,
+  // once for Description), which made any edit of an unresolved row overwrite
+  // the recorded reason with the comment text, or with NULL when there was none.
+  // Clear it here and let revalidation below restate why the row is still
+  // unresolved, matching refreshIngestionErrorsForMeasurement, which likewise
+  // resolves the row's existing error links before re-linking what still fails.
+  const clearedDescription = null;
 
   // UploadFileID / UploadBatchID are intentionally not in the failedmeasurements
   // allowlist (fieldpolicy.ts), so rejectDisallowedFields blocks any caller from
@@ -133,7 +137,7 @@ export async function writeFailedMeasurements(cm: ConnectionManager, input: Appl
       resolvedDate,
       resolvedCodes,
       resolvedComments,
-      initialDescription,
+      clearedDescription,
       coreMeasurementID
     ],
     txID

--- a/frontend/config/editplan/writers/measurementssummary.test.ts
+++ b/frontend/config/editplan/writers/measurementssummary.test.ts
@@ -47,6 +47,24 @@ describe('resolveMeasurementViewRefreshTargets', () => {
     expect(result).toEqual({ mode: 'targeted', coreMeasurementIDs: [5, 42, 101] });
   });
 
+  it('expands to stem neighbors for plot-coordinate edits', async () => {
+    const cm = makeConnectionManager([{ CoreMeasurementID: 7 }]);
+
+    const result = await resolveMeasurementViewRefreshTargets(cm, 'forestgeo_testing', {
+      coreMeasurementID: 42,
+      plotID: 1,
+      censusID: 2,
+      changedFields: new Set(['StemPlotX', 'StemPlotY']),
+      beforeStemGUID: 11,
+      afterStemGUID: 11,
+      transactionID: 'tx-1'
+    });
+
+    expect(cm.executeQuery).toHaveBeenCalledTimes(1);
+    expect(cm.executeQuery.mock.calls[0][0]).toContain('WHERE cm.StemGUID IN (?)');
+    expect(result).toEqual({ mode: 'targeted', coreMeasurementIDs: [7, 42] });
+  });
+
   it('falls back to the scope refresh for unsupported changed fields', async () => {
     const cm = makeConnectionManager();
 

--- a/frontend/config/editplan/writers/measurementssummary.ts
+++ b/frontend/config/editplan/writers/measurementssummary.ts
@@ -36,6 +36,8 @@ const RAW_SYNC_TRIGGER_FIELDS: ReadonlySet<string> = new Set([
   'QuadratName',
   'StemLocalX',
   'StemLocalY',
+  'StemPlotX',
+  'StemPlotY',
   'MeasuredDBH',
   'MeasuredHOM',
   'MeasurementDate',
@@ -43,7 +45,16 @@ const RAW_SYNC_TRIGGER_FIELDS: ReadonlySet<string> = new Set([
   'Attributes'
 ]);
 
-const STEM_NEIGHBOR_REFRESH_FIELDS: ReadonlySet<string> = new Set(['SpeciesCode', 'TreeTag', 'StemTag', 'QuadratName', 'StemLocalX', 'StemLocalY']);
+const STEM_NEIGHBOR_REFRESH_FIELDS: ReadonlySet<string> = new Set([
+  'SpeciesCode',
+  'TreeTag',
+  'StemTag',
+  'QuadratName',
+  'StemLocalX',
+  'StemLocalY',
+  'StemPlotX',
+  'StemPlotY'
+]);
 
 export type MeasurementViewRefreshTargetDecision =
   | { mode: 'targeted'; coreMeasurementIDs: number[] }
@@ -167,6 +178,8 @@ interface LoadedCoreMeasurementRow {
   StemTag: string | null;
   StemLocalX: number | string | null;
   StemLocalY: number | string | null;
+  StemPlotX: number | string | null;
+  StemPlotY: number | string | null;
   QuadratName: string | null;
   QuadratID?: number | null;
 }
@@ -197,6 +210,8 @@ async function loadCurrentJoinedRow(
        s.StemTag,
        s.LocalX AS StemLocalX,
        s.LocalY AS StemLocalY,
+       COALESCE(cm.RawPlotX, s.PlotX) AS StemPlotX,
+       COALESCE(cm.RawPlotY, s.PlotY) AS StemPlotY,
        q.QuadratName
      FROM ??.coremeasurements cm
      JOIN ??.census c ON c.CensusID = cm.CensusID
@@ -552,6 +567,22 @@ export async function writeMeasurementsSummary(cm: ConnectionManager, input: App
     }
   }
 
+  // --- StemPlotX / StemPlotY update: propagates to the shared stems row, and
+  //     the Raw* sync below stamps RawPlotX/RawPlotY on this measurement so the
+  //     COALESCE(cm.RawPlotX, s.PlotX) read model shows the edited value.
+  if (changedFields.has('StemPlotX') || changedFields.has('StemPlotY')) {
+    changesFound = true;
+    const plotXValue = changedFields.has('StemPlotX') ? toOptionalNumber(newValues.StemPlotX) : toOptionalNumber(merged.StemPlotX);
+    const plotYValue = changedFields.has('StemPlotY') ? toOptionalNumber(newValues.StemPlotY) : toOptionalNumber(merged.StemPlotY);
+    if (merged.StemGUID !== null && merged.StemGUID !== undefined) {
+      await cm.executeQuery(
+        format(`UPDATE ?? SET ? WHERE ?? = ?`, [`${schema}.stems`, { PlotX: plotXValue, PlotY: plotYValue }, 'StemGUID', merged.StemGUID]),
+        [],
+        txID
+      );
+    }
+  }
+
   // --- Numeric measurement fields on coremeasurements
   if (changedFields.has('MeasuredDBH') || changedFields.has('MeasuredHOM') || changedFields.has('MeasurementDate')) {
     changesFound = true;
@@ -607,26 +638,29 @@ export async function writeMeasurementsSummary(cm: ConnectionManager, input: App
   const shouldSyncRaw = Array.from(changedFields).some(f => RAW_SYNC_TRIGGER_FIELDS.has(f));
   if (shouldSyncRaw) {
     changesFound = true;
+    const rawSyncValues: Record<string, unknown> = {
+      RawTreeTag: merged.TreeTag ?? current.TreeTag ?? null,
+      RawStemTag: merged.StemTag ?? current.StemTag ?? null,
+      RawSpCode: merged.SpeciesCode ?? current.SpeciesCode ?? null,
+      RawQuadrat: merged.QuadratName ?? current.QuadratName ?? null,
+      RawX: toOptionalNumber(effective('StemLocalX')),
+      RawY: toOptionalNumber(effective('StemLocalY')),
+      RawCodes: effective('Attributes') ?? null,
+      RawComments: effective('Description') ?? null,
+      Description: effective('Description') ?? null,
+      MeasurementDate: normalizedMeasurementDate,
+      MeasuredDBH: toOptionalNumber(effective('MeasuredDBH')),
+      MeasuredHOM: toOptionalNumber(effective('MeasuredHOM'))
+    };
+    // RawPlotX/RawPlotY sync only on an actual plot-coordinate edit. The
+    // loaded StemPlotX is COALESCE(cm.RawPlotX, s.PlotX), so unconditional
+    // sync would stamp the stem's canonical value into a NULL raw column,
+    // fabricating an "as uploaded" plot coordinate for a row whose file never
+    // supplied one (and enrolling it in raw-axes-only validation 19).
+    if (changedFields.has('StemPlotX')) rawSyncValues.RawPlotX = toOptionalNumber(newValues.StemPlotX);
+    if (changedFields.has('StemPlotY')) rawSyncValues.RawPlotY = toOptionalNumber(newValues.StemPlotY);
     await cm.executeQuery(
-      format(`UPDATE ?? SET ? WHERE ?? = ?`, [
-        `${schema}.coremeasurements`,
-        {
-          RawTreeTag: merged.TreeTag ?? current.TreeTag ?? null,
-          RawStemTag: merged.StemTag ?? current.StemTag ?? null,
-          RawSpCode: merged.SpeciesCode ?? current.SpeciesCode ?? null,
-          RawQuadrat: merged.QuadratName ?? current.QuadratName ?? null,
-          RawX: toOptionalNumber(effective('StemLocalX')),
-          RawY: toOptionalNumber(effective('StemLocalY')),
-          RawCodes: effective('Attributes') ?? null,
-          RawComments: effective('Description') ?? null,
-          Description: effective('Description') ?? null,
-          MeasurementDate: normalizedMeasurementDate,
-          MeasuredDBH: toOptionalNumber(effective('MeasuredDBH')),
-          MeasuredHOM: toOptionalNumber(effective('MeasuredHOM'))
-        },
-        'CoreMeasurementID',
-        coreMeasurementID
-      ]),
+      format(`UPDATE ?? SET ? WHERE ?? = ?`, [`${schema}.coremeasurements`, rawSyncValues, 'CoreMeasurementID', coreMeasurementID]),
       [],
       txID
     );

--- a/frontend/config/editplan/writers/measurementssummary.ts
+++ b/frontend/config/editplan/writers/measurementssummary.ts
@@ -572,14 +572,11 @@ export async function writeMeasurementsSummary(cm: ConnectionManager, input: App
   //     COALESCE(cm.RawPlotX, s.PlotX) read model shows the edited value.
   if (changedFields.has('StemPlotX') || changedFields.has('StemPlotY')) {
     changesFound = true;
-    const plotXValue = changedFields.has('StemPlotX') ? toOptionalNumber(newValues.StemPlotX) : toOptionalNumber(merged.StemPlotX);
-    const plotYValue = changedFields.has('StemPlotY') ? toOptionalNumber(newValues.StemPlotY) : toOptionalNumber(merged.StemPlotY);
+    const stemPlotChanges: Record<string, number | null> = {};
+    if (changedFields.has('StemPlotX')) stemPlotChanges.PlotX = toOptionalNumber(newValues.StemPlotX);
+    if (changedFields.has('StemPlotY')) stemPlotChanges.PlotY = toOptionalNumber(newValues.StemPlotY);
     if (merged.StemGUID !== null && merged.StemGUID !== undefined) {
-      await cm.executeQuery(
-        format(`UPDATE ?? SET ? WHERE ?? = ?`, [`${schema}.stems`, { PlotX: plotXValue, PlotY: plotYValue }, 'StemGUID', merged.StemGUID]),
-        [],
-        txID
-      );
+      await cm.executeQuery(format(`UPDATE ?? SET ? WHERE ?? = ?`, [`${schema}.stems`, stemPlotChanges, 'StemGUID', merged.StemGUID]), [], txID);
     }
   }
 

--- a/frontend/config/errorsexplorer.test.ts
+++ b/frontend/config/errorsexplorer.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+import { INGESTION_ERROR_FIELD_MAP } from './errorsexplorer';
+
+describe('INGESTION_ERROR_FIELD_MAP', () => {
+  it('maps UNCLASSIFIED_REJECT to no fields, same as the other fieldless system codes', () => {
+    expect(INGESTION_ERROR_FIELD_MAP.UNCLASSIFIED_REJECT).toEqual([]);
+    expect(INGESTION_ERROR_FIELD_MAP.INTERRUPTED_UPLOAD).toEqual([]);
+  });
+});

--- a/frontend/config/errorsexplorer.test.ts
+++ b/frontend/config/errorsexplorer.test.ts
@@ -11,4 +11,21 @@ describe('INGESTION_ERROR_FIELD_MAP', () => {
   it('routes INVALID_COORDINATE to both local and plot coordinate fields, since a storage-range reject can come from either pair', () => {
     expect(INGESTION_ERROR_FIELD_MAP.INVALID_COORDINATE).toEqual(['stemLocalX', 'stemLocalY', 'stemPlotX', 'stemPlotY']);
   });
+
+  // The point of classifying these shapes at all is that the explorer can
+  // highlight the offending cell. A code with no entry here is no more useful
+  // to a researcher than the UNCLASSIFIED_REJECT it replaced.
+  it('points every parser-reject code at the cell the researcher has to fix', () => {
+    expect(INGESTION_ERROR_FIELD_MAP.NON_NUMERIC_DBH).toEqual(['measuredDBH']);
+    expect(INGESTION_ERROR_FIELD_MAP.NON_NUMERIC_HOM).toEqual(['measuredHOM']);
+    expect(INGESTION_ERROR_FIELD_MAP.NON_NUMERIC_COORDINATE).toEqual(['stemLocalX', 'stemLocalY', 'stemPlotX', 'stemPlotY']);
+    expect(INGESTION_ERROR_FIELD_MAP.INVALID_DATE).toEqual(['measurementDate']);
+    expect(INGESTION_ERROR_FIELD_MAP.MALFORMED_ROW).toEqual(['treeTag', 'stemTag']);
+  });
+
+  it('keeps the retired MISSING_FIELD_COORDINATES entry so pre-split rows still highlight their coordinates', () => {
+    expect(INGESTION_ERROR_FIELD_MAP.MISSING_FIELD_COORDINATES).toEqual(['stemLocalX', 'stemLocalY']);
+    expect(INGESTION_ERROR_FIELD_MAP.MISSING_FIELD_LOCALX).toEqual(['stemLocalX']);
+    expect(INGESTION_ERROR_FIELD_MAP.MISSING_FIELD_LOCALY).toEqual(['stemLocalY']);
+  });
 });

--- a/frontend/config/errorsexplorer.test.ts
+++ b/frontend/config/errorsexplorer.test.ts
@@ -7,4 +7,8 @@ describe('INGESTION_ERROR_FIELD_MAP', () => {
     expect(INGESTION_ERROR_FIELD_MAP.UNCLASSIFIED_REJECT).toEqual([]);
     expect(INGESTION_ERROR_FIELD_MAP.INTERRUPTED_UPLOAD).toEqual([]);
   });
+
+  it('routes INVALID_COORDINATE to both local and plot coordinate fields, since a storage-range reject can come from either pair', () => {
+    expect(INGESTION_ERROR_FIELD_MAP.INVALID_COORDINATE).toEqual(['stemLocalX', 'stemLocalY', 'stemPlotX', 'stemPlotY']);
+  });
 });

--- a/frontend/config/errorsexplorer.ts
+++ b/frontend/config/errorsexplorer.ts
@@ -236,7 +236,14 @@ export const INGESTION_ERROR_FIELD_MAP: Record<string, string[]> = {
   DUPLICATE_TAG_CONFLICT_EXISTING: ['treeTag', 'stemTag'],
   NEGATIVE_DBH: ['measuredDBH'],
   NEGATIVE_HOM: ['measuredHOM'],
+  // Retired code — see config/measurementerrors.ts. Kept so rows persisted
+  // under the old grouped lx/ly code still highlight their coordinate cells.
   MISSING_FIELD_COORDINATES: ['stemLocalX', 'stemLocalY'],
+  NON_NUMERIC_DBH: ['measuredDBH'],
+  NON_NUMERIC_HOM: ['measuredHOM'],
+  NON_NUMERIC_COORDINATE: ['stemLocalX', 'stemLocalY', 'stemPlotX', 'stemPlotY'],
+  INVALID_DATE: ['measurementDate'],
+  MALFORMED_ROW: ['treeTag', 'stemTag'],
   // A storage-range reject can come from lx/ly OR px/py (Decimal value for lx|ly|px|py is out of
   // range) — the reason text doesn't say which pair, so route to both local and plot fields rather
   // than falsely pinning it on lx/ly alone.

--- a/frontend/config/errorsexplorer.ts
+++ b/frontend/config/errorsexplorer.ts
@@ -243,6 +243,8 @@ export const INGESTION_ERROR_FIELD_MAP: Record<string, string[]> = {
   // No field is at fault — the upload was cut off before the row was judged.
   INTERRUPTED_UPLOAD: [],
   SQL_EXCEPTION: [],
+  // No field is at fault — the reject predates reason recording or its reason is unrecognized.
+  UNCLASSIFIED_REJECT: [],
   SAME_BATCH_SPECIES_CONFLICT: ['treeTag', 'speciesCode']
 };
 

--- a/frontend/config/errorsexplorer.ts
+++ b/frontend/config/errorsexplorer.ts
@@ -237,7 +237,10 @@ export const INGESTION_ERROR_FIELD_MAP: Record<string, string[]> = {
   NEGATIVE_DBH: ['measuredDBH'],
   NEGATIVE_HOM: ['measuredHOM'],
   MISSING_FIELD_COORDINATES: ['stemLocalX', 'stemLocalY'],
-  INVALID_COORDINATE: ['stemLocalX', 'stemLocalY'],
+  // A storage-range reject can come from lx/ly OR px/py (Decimal value for lx|ly|px|py is out of
+  // range) — the reason text doesn't say which pair, so route to both local and plot fields rather
+  // than falsely pinning it on lx/ly alone.
+  INVALID_COORDINATE: ['stemLocalX', 'stemLocalY', 'stemPlotX', 'stemPlotY'],
   FIELD_TOO_LONG: [],
   MISSING_MEASUREMENT_DATA: ['measuredDBH', 'measuredHOM'],
   // No field is at fault — the upload was cut off before the row was judged.

--- a/frontend/config/measurementerrors.test.ts
+++ b/frontend/config/measurementerrors.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildFailedMeasurementsSelectQuery,
+  classifyIngestionFailure,
   ensureMeasurementErrorDefinition,
   FALLBACK_FAILURE_REASON,
   getIngestionErrorMessage,
@@ -402,6 +403,21 @@ describe('measurementerrors helpers', () => {
     const params = insertCall![1] as unknown[];
     expect(params[4]).toBe('Unrecognized failure text for sequential path'); // Description = reason
     expect(params[16]).toBe('broken stem'); // RawComments = comments
+  });
+
+  it('classifies explicit system-failure kinds directly, bypassing reason inference', () => {
+    expect(classifyIngestionFailure('sql_exception', 'wording with no keywords')).toEqual([
+      { errorCode: 'SQL_EXCEPTION', errorMessage: getIngestionErrorMessage('SQL_EXCEPTION') }
+    ]);
+    expect(classifyIngestionFailure('interrupted_upload', 'GatewayTimeout')).toEqual([
+      { errorCode: 'INTERRUPTED_UPLOAD', errorMessage: getIngestionErrorMessage('INTERRUPTED_UPLOAD') }
+    ]);
+  });
+
+  it('still classifies parser_reject via reason-text inference (unchanged behavior)', () => {
+    expect(classifyIngestionFailure('parser_reject', 'Missing required field: TreeTag')).toEqual([
+      { errorCode: 'MISSING_FIELD_TREETAG', errorMessage: getIngestionErrorMessage('MISSING_FIELD_TREETAG') }
+    ]);
   });
 });
 

--- a/frontend/config/measurementerrors.test.ts
+++ b/frontend/config/measurementerrors.test.ts
@@ -6,7 +6,8 @@ import {
   getIngestionErrorMessage,
   inferAllIngestionErrorCodes,
   insertIngestionFailureRows,
-  revalidateEditedFailedRow
+  revalidateEditedFailedRow,
+  toFiniteNumber
 } from './measurementerrors';
 
 vi.mock('@/ailogger', () => ({
@@ -18,6 +19,19 @@ vi.mock('@/ailogger', () => ({
 }));
 
 describe('measurementerrors helpers', () => {
+  it('accepts only finite base-10 scalar values that fit the failed-row DECIMAL columns', () => {
+    expect(toFiniteNumber(' -12.5e2 ')).toBe(-1250);
+    expect(toFiniteNumber(0)).toBe(0);
+    expect(toFiniteNumber('999999.999999')).toBe(999999.999999);
+
+    expect(toFiniteNumber(true)).toBeNull();
+    expect(toFiniteNumber([])).toBeNull();
+    expect(toFiniteNumber('0x10')).toBeNull();
+    expect(toFiniteNumber('Infinity')).toBeNull();
+    expect(toFiniteNumber(1000000)).toBeNull();
+    expect(toFiniteNumber('-1000000')).toBeNull();
+  });
+
   it('includes stored coremeasurement descriptions in failed-measurements queries', () => {
     const sql = buildFailedMeasurementsSelectQuery('forestgeo_testing');
 

--- a/frontend/config/measurementerrors.test.ts
+++ b/frontend/config/measurementerrors.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   buildFailedMeasurementsSelectQuery,
   ensureMeasurementErrorDefinition,
+  FALLBACK_FAILURE_REASON,
   getIngestionErrorMessage,
   inferAllIngestionErrorCodes,
   insertIngestionFailureRows,
@@ -306,6 +307,101 @@ describe('measurementerrors helpers', () => {
     });
     expect(String(executeQuery.mock.calls[1]?.[0])).toContain('IsActive = 1');
     expect(String(executeQuery.mock.calls[2]?.[0])).toContain('LOWER(SpeciesCode) = LOWER(?)');
+  });
+
+  it('persists the failure reason into Description and keeps comments in RawComments only', async () => {
+    const executeQuery = vi
+      .fn()
+      .mockResolvedValueOnce({ insertId: 1001 }) // ensureMeasurementErrorDefinition upsert
+      .mockResolvedValueOnce({ affectedRows: 1 }) // bulk INSERT
+      .mockResolvedValueOnce([{ CoreMeasurementID: 90, SourceRowIndex: 1 }]) // SELECT-back
+      .mockResolvedValueOnce(undefined); // error-log INSERT
+    const connectionManager = { executeQuery } as any;
+
+    await insertIngestionFailureRows(connectionManager, 'forestgeo_testing', [
+      {
+        plotID: 1,
+        censusID: 2,
+        tag: 'T-9',
+        stemTag: '1',
+        spCode: 'ULMALA',
+        quadrat: 'A01',
+        comments: 'leaning stem',
+        failureReason: 'Non-numeric value for dbh: n/a',
+        fileID: 'upload.csv',
+        batchID: 'batch-9',
+        sourceRowIndex: 1
+      }
+    ]);
+
+    const insertCall = executeQuery.mock.calls.find(([sql]: [string]) => sql.includes('INSERT INTO `forestgeo_testing`.coremeasurements'));
+    const params = insertCall![1] as unknown[];
+    expect(params[4]).toBe('Non-numeric value for dbh: n/a'); // Description = reason
+    expect(params[16]).toBe('leaning stem'); // RawComments = comments
+  });
+
+  it('falls back to FALLBACK_FAILURE_REASON when the reason is blank', async () => {
+    const executeQuery = vi
+      .fn()
+      .mockResolvedValueOnce({ insertId: 1001 })
+      .mockResolvedValueOnce({ affectedRows: 1 })
+      .mockResolvedValueOnce([{ CoreMeasurementID: 91, SourceRowIndex: 1 }])
+      .mockResolvedValueOnce(undefined);
+    const connectionManager = { executeQuery } as any;
+
+    await insertIngestionFailureRows(connectionManager, 'forestgeo_testing', [
+      { plotID: 1, censusID: 2, failureReason: '   ', fileID: 'upload.csv', batchID: 'batch-9', sourceRowIndex: 1 }
+    ]);
+
+    const insertCall = executeQuery.mock.calls.find(([sql]: [string]) => sql.includes('INSERT INTO `forestgeo_testing`.coremeasurements'));
+    expect((insertCall![1] as unknown[])[4]).toBe(FALLBACK_FAILURE_REASON);
+  });
+
+  it('truncates over-length reasons to the Description column width', async () => {
+    const executeQuery = vi
+      .fn()
+      .mockResolvedValueOnce({ insertId: 1001 })
+      .mockResolvedValueOnce({ affectedRows: 1 })
+      .mockResolvedValueOnce([{ CoreMeasurementID: 92, SourceRowIndex: 1 }])
+      .mockResolvedValueOnce(undefined);
+    const connectionManager = { executeQuery } as any;
+
+    await insertIngestionFailureRows(connectionManager, 'forestgeo_testing', [
+      { plotID: 1, censusID: 2, failureReason: 'x'.repeat(300), fileID: 'upload.csv', batchID: 'batch-9', sourceRowIndex: 1 }
+    ]);
+
+    const insertCall = executeQuery.mock.calls.find(([sql]: [string]) => sql.includes('INSERT INTO `forestgeo_testing`.coremeasurements'));
+    expect((insertCall![1] as unknown[])[4]).toBe('x'.repeat(255));
+  });
+
+  it('persists the failure reason into Description on the sequential insert path (no batchID)', async () => {
+    const executeQuery = vi
+      .fn()
+      .mockResolvedValueOnce({ insertId: 1001 }) // ensureMeasurementErrorDefinition upsert
+      .mockResolvedValueOnce({ insertId: 93 }) // row INSERT
+      .mockResolvedValueOnce(undefined); // error-log INSERT
+    const connectionManager = { executeQuery } as any;
+
+    await insertIngestionFailureRows(connectionManager, 'forestgeo_testing', [
+      {
+        plotID: 1,
+        censusID: 2,
+        tag: 'T-10',
+        stemTag: '1',
+        spCode: 'ULMALA',
+        quadrat: 'A01',
+        comments: 'broken stem',
+        failureReason: 'Unrecognized failure text for sequential path',
+        fileID: 'upload.csv',
+        batchID: null,
+        sourceRowIndex: null
+      }
+    ]);
+
+    const insertCall = executeQuery.mock.calls.find(([sql]: [string]) => sql.includes('INSERT INTO `forestgeo_testing`.coremeasurements'));
+    const params = insertCall![1] as unknown[];
+    expect(params[4]).toBe('Unrecognized failure text for sequential path'); // Description = reason
+    expect(params[16]).toBe('broken stem'); // RawComments = comments
   });
 });
 

--- a/frontend/config/measurementerrors.test.ts
+++ b/frontend/config/measurementerrors.test.ts
@@ -430,6 +430,42 @@ describe('measurementerrors helpers', () => {
   ])('parser inference returns UNCLASSIFIED_REJECT for unrecognized reason %j', reason => {
     expect(inferAllIngestionErrorCodes(reason)).toEqual(['UNCLASSIFIED_REJECT']);
   });
+
+  // These reasons are the ACTUAL strings validateMeasurementRow/resolveMeasurementChunk
+  // emit (lib/column-mapping/measurement-rows.ts) — plural "Missing required fields:"
+  // joined with ', ' over lowercase canonical labels, "Decimal value for X is out of
+  // range: <value>" for lx/ly/px/py/dbh/hom, and multi-error rows joined with '|'.
+  it('maps the plural missing-required-fields reason to per-field codes', () => {
+    expect(inferAllIngestionErrorCodes('Missing required fields: tag, stemtag, date')).toEqual([
+      'MISSING_FIELD_TREETAG',
+      'MISSING_FIELD_STEMTAG',
+      'MISSING_FIELD_DATE'
+    ]);
+    expect(inferAllIngestionErrorCodes('Missing required fields: lx, ly')).toEqual(['MISSING_FIELD_LOCALX', 'MISSING_FIELD_LOCALY']);
+  });
+
+  it('maps out-of-range coordinate rejects to INVALID_COORDINATE', () => {
+    expect(inferAllIngestionErrorCodes('Decimal value for lx is out of range: -0.3')).toEqual(['INVALID_COORDINATE']);
+    expect(inferAllIngestionErrorCodes('Decimal value for px is out of range: 12345678')).toEqual(['INVALID_COORDINATE']);
+  });
+
+  it('maps out-of-range negative dbh/hom to their sign codes', () => {
+    expect(inferAllIngestionErrorCodes('Decimal value for dbh is out of range: -5')).toEqual(['NEGATIVE_DBH']);
+    expect(inferAllIngestionErrorCodes('Decimal value for hom is out of range: -1.3')).toEqual(['NEGATIVE_HOM']);
+  });
+
+  it('collects every code from a |-joined multi-error reason', () => {
+    expect(inferAllIngestionErrorCodes('Missing required fields: tag|Decimal value for ly is out of range: -1.2')).toEqual([
+      'MISSING_FIELD_TREETAG',
+      'INVALID_COORDINATE'
+    ]);
+  });
+
+  it('silently drops an unrecognized label from the missing-fields list rather than inventing a code for it', () => {
+    // 'px' has no MISSING_FIELD_* code (it only participates in the decimal-range check),
+    // so it must not surface a bogus code or block the sibling 'tag' label from mapping.
+    expect(inferAllIngestionErrorCodes('Missing required fields: tag, px')).toEqual(['MISSING_FIELD_TREETAG']);
+  });
 });
 
 /**

--- a/frontend/config/measurementerrors.test.ts
+++ b/frontend/config/measurementerrors.test.ts
@@ -85,6 +85,16 @@ describe('measurementerrors helpers', () => {
 
     expect(logInsertCalls).toHaveLength(1);
     expect(logInsertCalls[0][1]).toEqual([77, 1001, 77, 1002]);
+
+    const lookupCall = lookupCalls[0];
+    expect(lookupCall[0]).toContain('UploadFileID <=> ?');
+    expect(lookupCall[1]).toEqual(['upload.csv', 'batch-1', 1]);
+  });
+
+  it('bounds and coerces runtime reject reasons before classification', () => {
+    expect(() => inferAllIngestionErrorCodes({ reason: 'not a string' })).not.toThrow();
+    expect(inferAllIngestionErrorCodes({ reason: 'not a string' })).toEqual(['UNCLASSIFIED_REJECT']);
+    expect(inferAllIngestionErrorCodes('x'.repeat(500))).toEqual(['UNCLASSIFIED_REJECT']);
   });
 
   it('writes RawPlotX/RawPlotY on the bulk insert path and refreshes them on ON DUPLICATE KEY UPDATE', async () => {

--- a/frontend/config/measurementerrors.test.ts
+++ b/frontend/config/measurementerrors.test.ts
@@ -419,6 +419,17 @@ describe('measurementerrors helpers', () => {
       { errorCode: 'MISSING_FIELD_TREETAG', errorMessage: getIngestionErrorMessage('MISSING_FIELD_TREETAG') }
     ]);
   });
+
+  it.each<(string | null)[]>([
+    [null],
+    [''],
+    ['   '],
+    ['Unknown parse error'],
+    ['some reason mentioning sql and deadlock'],
+    ['GatewayTimeout while flushing batch']
+  ])('parser inference returns UNCLASSIFIED_REJECT for unrecognized reason %j', reason => {
+    expect(inferAllIngestionErrorCodes(reason)).toEqual(['UNCLASSIFIED_REJECT']);
+  });
 });
 
 /**
@@ -426,7 +437,9 @@ describe('measurementerrors helpers', () => {
  * parked as SQL_EXCEPTION because the Azure front-end timeout and the abandoned
  * upload session produced reasons that matched no classifier pattern. An
  * interruption is not a data defect — the row was never judged at all — so it
- * must carry its own code.
+ * must carry its own code, sourced from the caller's explicit failure kind
+ * rather than sniffed out of the reason text (prose inference was removed —
+ * `inferAllIngestionErrorCodes` never returns INTERRUPTED_UPLOAD on its own).
  */
 describe('inferAllIngestionErrorCodes — upload interruptions', () => {
   const INTERRUPTION_REASONS = [
@@ -438,8 +451,10 @@ describe('inferAllIngestionErrorCodes — upload interruptions', () => {
     'Batch cancelled before completion'
   ];
 
-  it.each(INTERRUPTION_REASONS)('maps %j to INTERRUPTED_UPLOAD, not SQL_EXCEPTION', reason => {
-    expect(inferAllIngestionErrorCodes(reason)).toEqual(['INTERRUPTED_UPLOAD']);
+  it.each(INTERRUPTION_REASONS)('maps %j to INTERRUPTED_UPLOAD via the explicit kind, not SQL_EXCEPTION', reason => {
+    expect(classifyIngestionFailure('interrupted_upload', reason)).toEqual([
+      { errorCode: 'INTERRUPTED_UPLOAD', errorMessage: getIngestionErrorMessage('INTERRUPTED_UPLOAD') }
+    ]);
   });
 
   it('gives INTERRUPTED_UPLOAD a message that distinguishes it from a rejected row', () => {
@@ -458,8 +473,12 @@ describe('inferAllIngestionErrorCodes — upload interruptions', () => {
     expect(inferAllIngestionErrorCodes('Duplicate measurement row detected')).toEqual(['DUPLICATE_ENTRY']);
   });
 
-  it('still defaults genuinely unmapped reasons to SQL_EXCEPTION', () => {
-    expect(inferAllIngestionErrorCodes('some brand new failure nobody has classified')).toEqual(['SQL_EXCEPTION']);
+  it.each(INTERRUPTION_REASONS)('no longer infers INTERRUPTED_UPLOAD from reason prose — %j defaults to UNCLASSIFIED_REJECT', reason => {
+    expect(inferAllIngestionErrorCodes(reason)).toEqual(['UNCLASSIFIED_REJECT']);
+  });
+
+  it('still defaults genuinely unmapped reasons to UNCLASSIFIED_REJECT, never SQL_EXCEPTION', () => {
+    expect(inferAllIngestionErrorCodes('some brand new failure nobody has classified')).toEqual(['UNCLASSIFIED_REJECT']);
   });
 
   /**

--- a/frontend/config/measurementerrors.test.ts
+++ b/frontend/config/measurementerrors.test.ts
@@ -7,6 +7,7 @@ import {
   FALLBACK_FAILURE_REASON,
   getIngestionErrorMessage,
   inferAllIngestionErrorCodes,
+  inferSystemFailureKind,
   insertIngestionFailureRows,
   revalidateEditedFailedRow,
   toFiniteNumber
@@ -557,5 +558,107 @@ describe('inferAllIngestionErrorCodes — upload interruptions', () => {
     expect(params[1]).toBe('INTERRUPTED_UPLOAD');
     expect(String(params[2]).toLowerCase()).toContain('interrupted');
     expect(transactionID).toBe('tx-9');
+  });
+});
+
+describe('inferSystemFailureKind — the setupbulkfailure reason boundary', () => {
+  // setupbulkfailure is the only transfer whose failure kind is not known by
+  // its caller: the browser sends whatever killed its setupbulkprocedure
+  // request as free text. Hardcoding 'sql_exception' there is what parked
+  // 106,227 clean Harvard Forest rows as if each carried a data error.
+  const CLIENT_INTERRUPTION_REASONS = [
+    'Server error 504: 504.0 GatewayTimeout',
+    'Upload session upload_ms3jw74a_97uvta1zlug cleaned up after abandonment',
+    'Client disconnected',
+    'Batch cancelled before completion',
+    // Composed by uploadfiresql's own fetchWithTimeout / abort paths.
+    'Request timeout after 480000ms',
+    'Request aborted for /api/setupbulkprocedure/file-1/batch-1',
+    // The browser's native fetch failures.
+    'TypeError: Failed to fetch',
+    'NetworkError when attempting to fetch resource.',
+    'Load failed'
+  ];
+
+  it.each(CLIENT_INTERRUPTION_REASONS)('classifies %j as interrupted_upload', reason => {
+    expect(inferSystemFailureKind(reason)).toBe('interrupted_upload');
+  });
+
+  const GENUINE_SERVER_FAILURE_REASONS = [
+    'Server error 500: Duplicate entry for key uq_coremeasurements',
+    'Client error (400): schema outside the authenticated user scope',
+    'Batch moved after max attempts',
+    'ER_LOCK_WAIT_TIMEOUT: Lock wait timeout exceeded'
+  ];
+
+  it.each(GENUINE_SERVER_FAILURE_REASONS)('leaves %j as sql_exception', reason => {
+    expect(inferSystemFailureKind(reason)).toBe('sql_exception');
+  });
+
+  it('defaults an absent or non-string reason to sql_exception rather than silently excusing the batch', () => {
+    expect(inferSystemFailureKind(undefined)).toBe('sql_exception');
+    expect(inferSystemFailureKind(null)).toBe('sql_exception');
+    expect(inferSystemFailureKind({ nested: 'gateway timeout' })).toBe('sql_exception');
+  });
+
+  it('produces the INTERRUPTED_UPLOAD code end-to-end for a front-end timeout', () => {
+    const reason = 'Server error 504: 504.0 GatewayTimeout';
+
+    expect(classifyIngestionFailure(inferSystemFailureKind(reason), reason)).toEqual([
+      { errorCode: 'INTERRUPTED_UPLOAD', errorMessage: getIngestionErrorMessage('INTERRUPTED_UPLOAD') }
+    ]);
+  });
+});
+
+describe('inferAllIngestionErrorCodes — parser reject shapes', () => {
+  // Every message validateMeasurementRow can emit must land on a code with a
+  // field map, otherwise the errors explorer shows the researcher a rejected
+  // row and no cell to fix.
+  it('classifies a non-numeric DBH, the single most common real reject', () => {
+    expect(inferAllIngestionErrorCodes('Non-numeric value for dbh: N/A')).toEqual(['NON_NUMERIC_DBH']);
+  });
+
+  it('classifies a non-numeric HOM', () => {
+    expect(inferAllIngestionErrorCodes('Non-numeric value for hom: unknown')).toEqual(['NON_NUMERIC_HOM']);
+  });
+
+  it.each(['lx', 'ly', 'px', 'py'])('classifies a non-numeric %s coordinate', field => {
+    expect(inferAllIngestionErrorCodes(`Non-numeric value for ${field}: ~12`)).toEqual(['NON_NUMERIC_COORDINATE']);
+  });
+
+  it('classifies an unparseable date', () => {
+    expect(inferAllIngestionErrorCodes('Unparseable date value: 31/02/2026')).toEqual(['INVALID_DATE']);
+  });
+
+  it('classifies a delimiter-contaminated tag pair as a mis-parsed row', () => {
+    const reason = 'Tag values contain delimiter character ",": tag="T1,S1", stemtag="". This suggests parsing error.';
+
+    expect(inferAllIngestionErrorCodes(reason)).toContain('MALFORMED_ROW');
+  });
+
+  it('classifies concatenated over-long tags as a mis-parsed row', () => {
+    const reason =
+      'Unusually long tag values detected: tag="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...", stemtag="BBB...". This may indicate concatenated fields due to parsing error.';
+
+    expect(inferAllIngestionErrorCodes(reason)).toContain('MALFORMED_ROW');
+  });
+
+  it('reports every defect on a row that trips more than one parser check', () => {
+    const reason = 'Missing required fields: quadrat | Non-numeric value for dbh: N/A | Unparseable date value: yesterday';
+
+    expect(inferAllIngestionErrorCodes(reason).sort()).toEqual(['INVALID_DATE', 'MISSING_FIELD_QUADRATNAME', 'NON_NUMERIC_DBH']);
+  });
+
+  it('never re-emits the retired MISSING_FIELD_COORDINATES code for an lx/ly reject', () => {
+    const codes = inferAllIngestionErrorCodes('Missing required fields: lx, ly');
+
+    expect(codes).toEqual(['MISSING_FIELD_LOCALX', 'MISSING_FIELD_LOCALY']);
+    expect(codes).not.toContain('MISSING_FIELD_COORDINATES');
+  });
+
+  it('still resolves the retired code for rows persisted under it before the per-field split', () => {
+    // Removing it from the catalog would leave historical rows with the generic
+    // 'Ingestion error' fallback in the explorer.
+    expect(getIngestionErrorMessage('MISSING_FIELD_COORDINATES')).toBe('Missing required coordinate fields (lx, ly)');
   });
 });

--- a/frontend/config/measurementerrors.ts
+++ b/frontend/config/measurementerrors.ts
@@ -6,6 +6,16 @@ import { MAX_STORED_DECIMAL, parseFiniteBase10Number } from '@/config/editplan/f
 export const INGESTION_ERROR_SOURCE = 'ingestion' as const;
 export const VALIDATION_ERROR_SOURCE = 'validation' as const;
 
+export const FALLBACK_FAILURE_REASON = 'Unknown parse error';
+// coremeasurements.Description is varchar(255); an over-length bind under strict
+// sql_mode would fail the whole audit insert, so truncate rather than throw.
+const FAILURE_DESCRIPTION_MAX_LENGTH = 255;
+
+function normalizeFailureDescription(failureReason?: string | null): string {
+  const trimmed = failureReason == null ? '' : String(failureReason).trim();
+  return (trimmed || FALLBACK_FAILURE_REASON).slice(0, FAILURE_DESCRIPTION_MAX_LENGTH);
+}
+
 export interface IngestionFailureRowInput {
   plotID: number;
   censusID: number;
@@ -128,6 +138,7 @@ interface PreparedIngestionFailureRow {
   resultIndex: number;
   row: IngestionFailureRowInput;
   normalizedDate: string | null;
+  description: string;
   sourceRowIndex: number;
   errors: MeasurementErrorInput[];
 }
@@ -246,6 +257,7 @@ function prepareIngestionFailureRows(rows: IngestionFailureRowInput[]): Prepared
     resultIndex: index,
     row,
     normalizedDate: normalizeDate(row.date),
+    description: normalizeFailureDescription(row.failureReason),
     sourceRowIndex: row.sourceRowIndex ?? index + 1,
     errors: inferAllIngestionErrorCodes(row.failureReason).map(code => ({
       errorCode: code,
@@ -317,7 +329,7 @@ async function insertPreparedIngestionFailureRowsSequential(
   );
 
   for (const preparedRow of rows) {
-    const { row, normalizedDate, sourceRowIndex, errors } = preparedRow;
+    const { row, normalizedDate, description, sourceRowIndex, errors } = preparedRow;
     const insertResult: any = await connectionManager.executeQuery(
       insertSQL,
       [
@@ -325,7 +337,7 @@ async function insertPreparedIngestionFailureRowsSequential(
         normalizedDate,
         row.dbh ?? null,
         row.hom ?? null,
-        row.comments ?? null,
+        description,
         row.fileID ?? null,
         row.batchID ?? null,
         row.tag ?? null,
@@ -394,12 +406,12 @@ async function insertPreparedIngestionFailureRowsBulk(
          IsValidated = FALSE`
     );
 
-    const insertParams = chunk.flatMap(({ row, normalizedDate, sourceRowIndex }) => [
+    const insertParams = chunk.flatMap(({ row, normalizedDate, description, sourceRowIndex }) => [
       row.censusID,
       normalizedDate,
       row.dbh ?? null,
       row.hom ?? null,
-      row.comments ?? null,
+      description,
       row.fileID ?? null,
       row.batchID ?? null,
       row.tag ?? null,

--- a/frontend/config/measurementerrors.ts
+++ b/frontend/config/measurementerrors.ts
@@ -565,10 +565,27 @@ const FIELD_LENGTH_LIMITS = {
   Codes: 255
 } as const;
 
+// Raw failed-row measurements are persisted in DECIMAL(12,6) columns. Keep
+// runtime values inside that representable range so malformed API payloads
+// cannot turn a rejected-row audit insert into a second database failure.
+const MAX_STORED_DECIMAL = 999999.999999;
+const BASE_10_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+
 export function toFiniteNumber(value: unknown): number | null {
-  if (value === null || value === undefined || (typeof value === 'string' && value.trim() === '')) return null;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
+  if (value === null || value === undefined) return null;
+
+  let parsed: number;
+  if (typeof value === 'number') {
+    parsed = value;
+  } else if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed === '' || !BASE_10_NUMBER_PATTERN.test(trimmed)) return null;
+    parsed = Number(trimmed);
+  } else {
+    return null;
+  }
+
+  return Number.isFinite(parsed) && Math.abs(parsed) <= MAX_STORED_DECIMAL ? parsed : null;
 }
 
 /**

--- a/frontend/config/measurementerrors.ts
+++ b/frontend/config/measurementerrors.ts
@@ -1,6 +1,7 @@
 import ConnectionManager from '@/lib/db/connectionmanager';
 import { safeFormatQuery } from '@/lib/db/sqlsecurity';
 import ailogger from '@/ailogger';
+import { MAX_STORED_DECIMAL, parseFiniteBase10Number } from '@/config/editplan/fieldpolicy';
 
 export const INGESTION_ERROR_SOURCE = 'ingestion' as const;
 export const VALIDATION_ERROR_SOURCE = 'validation' as const;
@@ -568,24 +569,10 @@ const FIELD_LENGTH_LIMITS = {
 // Raw failed-row measurements are persisted in DECIMAL(12,6) columns. Keep
 // runtime values inside that representable range so malformed API payloads
 // cannot turn a rejected-row audit insert into a second database failure.
-const MAX_STORED_DECIMAL = 999999.999999;
-const BASE_10_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
 
 export function toFiniteNumber(value: unknown): number | null {
-  if (value === null || value === undefined) return null;
-
-  let parsed: number;
-  if (typeof value === 'number') {
-    parsed = value;
-  } else if (typeof value === 'string') {
-    const trimmed = value.trim();
-    if (trimmed === '' || !BASE_10_NUMBER_PATTERN.test(trimmed)) return null;
-    parsed = Number(trimmed);
-  } else {
-    return null;
-  }
-
-  return Number.isFinite(parsed) && Math.abs(parsed) <= MAX_STORED_DECIMAL ? parsed : null;
+  const parsed = parseFiniteBase10Number(value);
+  return parsed !== null && Math.abs(parsed) <= MAX_STORED_DECIMAL ? parsed : null;
 }
 
 /**

--- a/frontend/config/measurementerrors.ts
+++ b/frontend/config/measurementerrors.ts
@@ -76,13 +76,26 @@ const INGESTION_ERROR_MESSAGES: Record<string, string> = {
   NEGATIVE_DBH: 'DBH must be non-negative',
   NEGATIVE_HOM: 'HOM must be non-negative',
   MISSING_FIELD_COORDINATES: 'Missing required coordinate fields (lx, ly)',
-  INVALID_COORDINATE: 'Coordinate value is negative',
+  INVALID_COORDINATE: 'Coordinate value is outside the accepted or storable range',
   FIELD_TOO_LONG: 'One or more fields exceed column length limits',
   MISSING_MEASUREMENT_DATA: 'Missing measurement data',
   INTERRUPTED_UPLOAD: 'Upload was interrupted before this row was processed (server timeout or cancelled session) — the row itself was not rejected',
   UNCLASSIFIED_REJECT: 'Row was rejected before ingestion; the recorded reason does not match a known error category',
   SQL_EXCEPTION: 'Ingestion SQL exception'
 };
+
+// Parser reject reasons use the lowercase canonical field labels from
+// lib/column-mapping (validateMeasurementRow joins them: "Missing required fields: tag, date").
+const MISSING_FIELD_CODES_BY_LABEL: Record<string, string> = {
+  tag: 'MISSING_FIELD_TREETAG',
+  stemtag: 'MISSING_FIELD_STEMTAG',
+  spcode: 'MISSING_FIELD_SPECIESCODE',
+  quadrat: 'MISSING_FIELD_QUADRATNAME',
+  date: 'MISSING_FIELD_DATE',
+  lx: 'MISSING_FIELD_LOCALX',
+  ly: 'MISSING_FIELD_LOCALY'
+};
+const MISSING_FIELDS_LIST_PATTERN = /missing required fields?:\s*([^|]+)/g;
 
 export function inferAllIngestionErrorCodes(reason?: string | null): string[] {
   const text = (reason || '').toLowerCase();
@@ -104,12 +117,26 @@ export function inferAllIngestionErrorCodes(reason?: string | null): string[] {
   if (text.includes('duplicate')) codes.push('DUPLICATE_ENTRY');
   if (text.includes('invalid dbh') || text.includes('negative dbh')) codes.push('NEGATIVE_DBH');
   if (text.includes('invalid hom') || text.includes('negative hom')) codes.push('NEGATIVE_HOM');
-  if (text.includes('missing required fields: lx') || text.includes('missing required fields: ly')) codes.push('MISSING_FIELD_COORDINATES');
   if (text.includes('missing required field: localx')) codes.push('MISSING_FIELD_LOCALX');
   if (text.includes('missing required field: localy')) codes.push('MISSING_FIELD_LOCALY');
   if (text.includes('invalid localx') || text.includes('invalid localy') || text.includes('invalid local')) codes.push('INVALID_COORDINATE');
   if (text.includes('exceeds maximum length') || text.includes('field too long')) codes.push('FIELD_TOO_LONG');
   if (text.includes('missing measurement data')) codes.push('MISSING_MEASUREMENT_DATA');
+
+  // Parser-emitted reject shapes (lib/column-mapping/measurement-rows.ts):
+  // "Missing required fields: tag, stemtag, date" (plural, lowercase canonical labels)
+  // and "Decimal value for <field> is out of range: <value>" for lx/ly/px/py/dbh/hom.
+  // A positive (too-large) dbh/hom overflow has no distinguishing sign in that text, so
+  // it deliberately falls through to UNCLASSIFIED_REJECT rather than guessing NEGATIVE_*.
+  for (const match of text.matchAll(MISSING_FIELDS_LIST_PATTERN)) {
+    for (const label of match[1].split(',').map(part => part.trim())) {
+      const code = MISSING_FIELD_CODES_BY_LABEL[label];
+      if (code) codes.push(code);
+    }
+  }
+  if (/decimal value for (lx|ly|px|py) is out of range/.test(text)) codes.push('INVALID_COORDINATE');
+  if (/decimal value for dbh is out of range: -/.test(text)) codes.push('NEGATIVE_DBH');
+  if (/decimal value for hom is out of range: -/.test(text)) codes.push('NEGATIVE_HOM');
 
   if (codes.length === 0) {
     ailogger.warn(`inferAllIngestionErrorCodes: unrecognized parser-reject reason: "${reason}"`);

--- a/frontend/config/measurementerrors.ts
+++ b/frontend/config/measurementerrors.ts
@@ -58,6 +58,41 @@ export function errorCodeForSystemFailure(kind: SystemFailureKind): string {
   return SYSTEM_FAILURE_ERROR_CODES[kind];
 }
 
+/**
+ * Reason fragments that mean "the upload was cut off", not "this row is bad".
+ * Rows carrying these were never judged by the ingestion procedure, so grouping
+ * them under SQL_EXCEPTION misreports clean data as defective — the failure mode
+ * behind the 2026-07-27 Harvard Forest incident, where an Azure front-end
+ * timeout parked 106,227 rows as if each one had a data error.
+ *
+ * Every other caller knows its own failure kind and passes it explicitly.
+ * setupbulkfailure is the one boundary that cannot: its reason is a free-text
+ * string composed by the browser from whatever killed the request, so the kind
+ * has to be recovered from that text here.
+ */
+const INTERRUPTION_REASON_FRAGMENTS = [
+  'gatewaytimeout',
+  'gateway timeout',
+  'server error 504',
+  'cleaned up after abandonment',
+  'client disconnected',
+  'batch cancelled before completion',
+  // Shapes the upload client itself composes when the request never reached a
+  // verdict: fetchWithTimeout's timeout message, an aborted batch, and the
+  // browser's own network-failure text (Chrome/Firefox vs Safari).
+  'request timeout after',
+  'request aborted for',
+  'failed to fetch',
+  'networkerror',
+  'network error',
+  'load failed'
+];
+
+export function inferSystemFailureKind(reason?: unknown): SystemFailureKind {
+  const text = normalizeFailureDescription(reason).toLowerCase();
+  return INTERRUPTION_REASON_FRAGMENTS.some(fragment => text.includes(fragment)) ? 'interrupted_upload' : 'sql_exception';
+}
+
 const INGESTION_ERROR_MESSAGES: Record<string, string> = {
   MISSING_FIELD_TREETAG: 'Missing required field: TreeTag',
   MISSING_FIELD_STEMTAG: 'Missing required field: StemTag',
@@ -75,11 +110,19 @@ const INGESTION_ERROR_MESSAGES: Record<string, string> = {
   DUPLICATE_ENTRY: 'Duplicate measurement row detected',
   NEGATIVE_DBH: 'DBH must be non-negative',
   NEGATIVE_HOM: 'HOM must be non-negative',
+  // Retired: lx/ly rejects now classify per field as MISSING_FIELD_LOCALX /
+  // MISSING_FIELD_LOCALY. Retained so rows persisted under the old grouped code
+  // still resolve to a message and to affected fields in the errors explorer.
   MISSING_FIELD_COORDINATES: 'Missing required coordinate fields (lx, ly)',
   INVALID_COORDINATE: 'Coordinate value is outside the accepted or storable range',
   FIELD_TOO_LONG: 'One or more fields exceed column length limits',
   MISSING_MEASUREMENT_DATA: 'Missing measurement data',
   INTERRUPTED_UPLOAD: 'Upload was interrupted before this row was processed (server timeout or cancelled session) — the row itself was not rejected',
+  NON_NUMERIC_DBH: 'DBH value is not numeric',
+  NON_NUMERIC_HOM: 'HOM value is not numeric',
+  NON_NUMERIC_COORDINATE: 'Coordinate value is not numeric',
+  INVALID_DATE: 'Measurement date could not be parsed',
+  MALFORMED_ROW: 'Row appears mis-parsed: tag fields contain the delimiter or are unusually long',
   UNCLASSIFIED_REJECT: 'Row was rejected before ingestion; the recorded reason does not match a known error category',
   SQL_EXCEPTION: 'Ingestion SQL exception'
 };
@@ -141,6 +184,18 @@ export function inferAllIngestionErrorCodes(reason?: unknown): string[] {
   if (/decimal value for (lx|ly|px|py) is out of range/.test(text)) codes.push('INVALID_COORDINATE');
   if (/decimal value for dbh is out of range: -/.test(text)) codes.push('NEGATIVE_DBH');
   if (/decimal value for hom is out of range: -/.test(text)) codes.push('NEGATIVE_HOM');
+
+  // The remaining shapes validateMeasurementRow emits. "dbh=N/A" and an
+  // unparseable date are the two most frequent real rejects, so leaving them on
+  // UNCLASSIFIED_REJECT (whose field map is empty) told a researcher a row was
+  // rejected without pointing at the cell to fix.
+  if (/non-numeric value for dbh/.test(text)) codes.push('NON_NUMERIC_DBH');
+  if (/non-numeric value for hom/.test(text)) codes.push('NON_NUMERIC_HOM');
+  // Like INVALID_COORDINATE, one code covers the local/plot pairs: the explorer
+  // highlights all four coordinate cells rather than mis-pinning the wrong pair.
+  if (/non-numeric value for (lx|ly|px|py)/.test(text)) codes.push('NON_NUMERIC_COORDINATE');
+  if (text.includes('unparseable date value')) codes.push('INVALID_DATE');
+  if (text.includes('contain delimiter character') || text.includes('unusually long tag values')) codes.push('MALFORMED_ROW');
 
   if (codes.length === 0) {
     ailogger.warn(`inferAllIngestionErrorCodes: unrecognized parser-reject reason: "${normalizedReason}"`);

--- a/frontend/config/measurementerrors.ts
+++ b/frontend/config/measurementerrors.ts
@@ -11,7 +11,7 @@ export const FALLBACK_FAILURE_REASON = 'Unknown parse error';
 // sql_mode would fail the whole audit insert, so truncate rather than throw.
 const FAILURE_DESCRIPTION_MAX_LENGTH = 255;
 
-function normalizeFailureDescription(failureReason?: string | null): string {
+export function normalizeFailureDescription(failureReason?: unknown): string {
   const trimmed = failureReason == null ? '' : String(failureReason).trim();
   return (trimmed || FALLBACK_FAILURE_REASON).slice(0, FAILURE_DESCRIPTION_MAX_LENGTH);
 }
@@ -97,8 +97,12 @@ const MISSING_FIELD_CODES_BY_LABEL: Record<string, string> = {
 };
 const MISSING_FIELDS_LIST_PATTERN = /missing required fields?:\s*([^|]+)/g;
 
-export function inferAllIngestionErrorCodes(reason?: string | null): string[] {
-  const text = (reason || '').toLowerCase();
+export function inferAllIngestionErrorCodes(reason?: unknown): string[] {
+  // This is called from an HTTP persistence boundary: TypeScript's string
+  // type does not constrain values decoded from JSON. Normalize once so
+  // classification and logging cannot throw or emit unbounded input.
+  const normalizedReason = normalizeFailureDescription(reason);
+  const text = normalizedReason.toLowerCase();
   const codes: string[] = [];
 
   if (text.includes('missing required field: treetag') || text.includes('missing treetag')) codes.push('MISSING_FIELD_TREETAG');
@@ -139,15 +143,17 @@ export function inferAllIngestionErrorCodes(reason?: string | null): string[] {
   if (/decimal value for hom is out of range: -/.test(text)) codes.push('NEGATIVE_HOM');
 
   if (codes.length === 0) {
-    ailogger.warn(`inferAllIngestionErrorCodes: unrecognized parser-reject reason: "${reason}"`);
+    ailogger.warn(`inferAllIngestionErrorCodes: unrecognized parser-reject reason: "${normalizedReason}"`);
     codes.push('UNCLASSIFIED_REJECT');
   }
 
   return Array.from(new Set(codes));
 }
 
-export function getIngestionErrorMessage(code: string, fallback?: string | null): string {
-  return INGESTION_ERROR_MESSAGES[code] || fallback || 'Ingestion error';
+export function getIngestionErrorMessage(code: string, fallback?: unknown): string {
+  if (INGESTION_ERROR_MESSAGES[code]) return INGESTION_ERROR_MESSAGES[code];
+  if (typeof fallback === 'string' && fallback.trim()) return normalizeFailureDescription(fallback);
+  return 'Ingestion error';
 }
 
 interface MeasurementErrorInput {
@@ -165,7 +171,7 @@ interface MeasurementErrorInput {
  * `errorCodeForSystemFailure`/`getIngestionErrorMessage` directly for the
  * same system-failure kinds.
  */
-export function classifyIngestionFailure(kind: IngestionFailureKind, failureReason?: string | null): MeasurementErrorInput[] {
+export function classifyIngestionFailure(kind: IngestionFailureKind, failureReason?: unknown): MeasurementErrorInput[] {
   if (kind !== 'parser_reject') {
     const errorCode = errorCodeForSystemFailure(kind);
     return [{ errorCode, errorMessage: getIngestionErrorMessage(errorCode, failureReason) }];
@@ -410,6 +416,7 @@ async function insertPreparedIngestionFailureRowsSequential(
 async function insertPreparedIngestionFailureRowsBulk(
   connectionManager: ConnectionManager,
   schema: string,
+  fileID: string | null,
   batchID: string,
   rows: PreparedIngestionFailureRow[],
   transactionID: string | undefined,
@@ -475,12 +482,13 @@ async function insertPreparedIngestionFailureRowsBulk(
       schema,
       `SELECT CoreMeasurementID, SourceRowIndex
        FROM ??.coremeasurements
-       WHERE UploadBatchID = ?
+       WHERE UploadFileID <=> ?
+         AND UploadBatchID <=> ?
          AND SourceRowIndex IN (${rowIndexes.map(() => '?').join(', ')})`
     );
     const measurementRows: Array<{ CoreMeasurementID: number; SourceRowIndex: number }> = await connectionManager.executeQuery(
       selectSQL,
-      [batchID, ...rowIndexes],
+      [fileID, batchID, ...rowIndexes],
       transactionID
     );
     const measurementIDBySourceRow = new Map(measurementRows.map(row => [row.SourceRowIndex, row.CoreMeasurementID]));
@@ -550,7 +558,7 @@ export async function insertIngestionFailureRows(
   const preparedRows = prepareIngestionFailureRows(rows);
   const errorIDCache = await resolveIngestionErrorIDCache(connectionManager, schema, preparedRows, transactionID);
 
-  const bulkEligibleRows = new Map<string, PreparedIngestionFailureRow[]>();
+  const bulkEligibleRows = new Map<string, { fileID: string | null; batchID: string; rows: PreparedIngestionFailureRow[] }>();
   const sequentialRows: PreparedIngestionFailureRow[] = [];
 
   for (const preparedRow of preparedRows) {
@@ -560,17 +568,19 @@ export async function insertIngestionFailureRows(
       continue;
     }
 
-    const group = bulkEligibleRows.get(batchID) ?? [];
-    group.push(preparedRow);
-    bulkEligibleRows.set(batchID, group);
+    const fileID = preparedRow.row.fileID ?? null;
+    const groupKey = `${fileID ?? '<NULL>'}\u0000${batchID}`;
+    const group = bulkEligibleRows.get(groupKey) ?? { fileID, batchID, rows: [] };
+    group.rows.push(preparedRow);
+    bulkEligibleRows.set(groupKey, group);
   }
 
   const insertedIDs: number[] = [];
   const insertedIDByRow = new Map<number, number>();
 
-  for (const [batchID, batchRows] of bulkEligibleRows.entries()) {
+  for (const { fileID, batchID, rows: batchRows } of bulkEligibleRows.values()) {
     for (const [rowIndex, measurementID] of (
-      await insertPreparedIngestionFailureRowsBulk(connectionManager, schema, batchID, batchRows, transactionID, errorIDCache)
+      await insertPreparedIngestionFailureRowsBulk(connectionManager, schema, fileID, batchID, batchRows, transactionID, errorIDCache)
     ).entries()) {
       insertedIDByRow.set(rowIndex, measurementID);
     }

--- a/frontend/config/measurementerrors.ts
+++ b/frontend/config/measurementerrors.ts
@@ -36,6 +36,26 @@ export interface IngestionFailureRowInput {
   fileID?: string | null;
   batchID?: string | null;
   sourceRowIndex?: number | null;
+  failureKind?: IngestionFailureKind;
+}
+
+/**
+ * `parser_reject` covers per-row validation rejects, where the specific defect
+ * (missing field, invalid reference, ...) is still unknown until the reason
+ * text is classified. `sql_exception` and `interrupted_upload` are system
+ * failures — the caller already knows which one happened and must say so
+ * explicitly rather than have it guessed from prose.
+ */
+export type IngestionFailureKind = 'parser_reject' | 'sql_exception' | 'interrupted_upload';
+export type SystemFailureKind = Exclude<IngestionFailureKind, 'parser_reject'>;
+
+const SYSTEM_FAILURE_ERROR_CODES: Record<SystemFailureKind, string> = {
+  sql_exception: 'SQL_EXCEPTION',
+  interrupted_upload: 'INTERRUPTED_UPLOAD'
+};
+
+export function errorCodeForSystemFailure(kind: SystemFailureKind): string {
+  return SYSTEM_FAILURE_ERROR_CODES[kind];
 }
 
 const INGESTION_ERROR_MESSAGES: Record<string, string> = {
@@ -130,6 +150,24 @@ export function getIngestionErrorMessage(code: string, fallback?: string | null)
 interface MeasurementErrorInput {
   errorCode: string;
   errorMessage: string;
+}
+
+/**
+ * The single choke point for turning a failure into an error code. A
+ * `parser_reject` still needs the reason text classified (the specific
+ * per-row defect isn't known up front); every other kind is a system failure
+ * the caller has already identified, so it maps straight to its code and
+ * never runs prose inference over the reason text.
+ */
+export function classifyIngestionFailure(kind: IngestionFailureKind, failureReason?: string | null): MeasurementErrorInput[] {
+  if (kind !== 'parser_reject') {
+    const errorCode = errorCodeForSystemFailure(kind);
+    return [{ errorCode, errorMessage: getIngestionErrorMessage(errorCode, failureReason) }];
+  }
+  return inferAllIngestionErrorCodes(failureReason).map(code => ({
+    errorCode: code,
+    errorMessage: getIngestionErrorMessage(code, failureReason)
+  }));
 }
 
 const INGESTION_FAILURE_BULK_INSERT_SIZE = 250;
@@ -259,10 +297,7 @@ function prepareIngestionFailureRows(rows: IngestionFailureRowInput[]): Prepared
     normalizedDate: normalizeDate(row.date),
     description: normalizeFailureDescription(row.failureReason),
     sourceRowIndex: row.sourceRowIndex ?? index + 1,
-    errors: inferAllIngestionErrorCodes(row.failureReason).map(code => ({
-      errorCode: code,
-      errorMessage: getIngestionErrorMessage(code, row.failureReason)
-    }))
+    errors: classifyIngestionFailure(row.failureKind ?? 'parser_reject', row.failureReason)
   }));
 }
 

--- a/frontend/config/measurementerrors.ts
+++ b/frontend/config/measurementerrors.ts
@@ -80,29 +80,9 @@ const INGESTION_ERROR_MESSAGES: Record<string, string> = {
   FIELD_TOO_LONG: 'One or more fields exceed column length limits',
   MISSING_MEASUREMENT_DATA: 'Missing measurement data',
   INTERRUPTED_UPLOAD: 'Upload was interrupted before this row was processed (server timeout or cancelled session) — the row itself was not rejected',
+  UNCLASSIFIED_REJECT: 'Row was rejected before ingestion; the recorded reason does not match a known error category',
   SQL_EXCEPTION: 'Ingestion SQL exception'
 };
-
-/**
- * Reason fragments that mean "the upload was cut off", not "this row is bad".
- * Rows carrying these were never judged by the ingestion procedure, so grouping
- * them under SQL_EXCEPTION misreports clean data as defective — the failure mode
- * behind the 2026-07-27 Harvard Forest incident, where an Azure front-end
- * timeout parked 106,227 rows as if each one had a data error.
- */
-const INTERRUPTION_REASON_FRAGMENTS = [
-  'gatewaytimeout',
-  'gateway timeout',
-  'server error 504',
-  'cleaned up after abandonment',
-  'client disconnected',
-  'batch cancelled before completion'
-];
-
-export function inferIngestionErrorCode(reason?: string | null): string {
-  const codes = inferAllIngestionErrorCodes(reason);
-  return codes[0];
-}
 
 export function inferAllIngestionErrorCodes(reason?: string | null): string[] {
   const text = (reason || '').toLowerCase();
@@ -131,13 +111,9 @@ export function inferAllIngestionErrorCodes(reason?: string | null): string[] {
   if (text.includes('exceeds maximum length') || text.includes('field too long')) codes.push('FIELD_TOO_LONG');
   if (text.includes('missing measurement data')) codes.push('MISSING_MEASUREMENT_DATA');
 
-  if (codes.length === 0 && INTERRUPTION_REASON_FRAGMENTS.some(fragment => text.includes(fragment))) {
-    codes.push('INTERRUPTED_UPLOAD');
-  }
-
   if (codes.length === 0) {
-    ailogger.warn(`inferAllIngestionErrorCodes: unmapped error pattern defaulting to SQL_EXCEPTION: "${reason}"`);
-    codes.push('SQL_EXCEPTION');
+    ailogger.warn(`inferAllIngestionErrorCodes: unrecognized parser-reject reason: "${reason}"`);
+    codes.push('UNCLASSIFIED_REJECT');
   }
 
   return Array.from(new Set(codes));
@@ -153,11 +129,14 @@ interface MeasurementErrorInput {
 }
 
 /**
- * The single choke point for turning a failure into an error code. A
- * `parser_reject` still needs the reason text classified (the specific
- * per-row defect isn't known up front); every other kind is a system failure
- * the caller has already identified, so it maps straight to its code and
- * never runs prose inference over the reason text.
+ * Turns a failure into an error code. A `parser_reject` still needs the
+ * reason text classified (the specific per-row defect isn't known up
+ * front); every other kind is a system failure the caller has already
+ * identified, so it maps straight to its code and never runs prose
+ * inference over the reason text. Not the only caller of these
+ * primitives — `lib/batchfailuretransfer.ts` composes code+message from
+ * `errorCodeForSystemFailure`/`getIngestionErrorMessage` directly for the
+ * same system-failure kinds.
  */
 export function classifyIngestionFailure(kind: IngestionFailureKind, failureReason?: string | null): MeasurementErrorInput[] {
   if (kind !== 'parser_reject') {

--- a/frontend/config/uploadsessiontracker.test.ts
+++ b/frontend/config/uploadsessiontracker.test.ts
@@ -83,10 +83,47 @@ describe('cleanupOrphanedData', () => {
       'file.csv',
       'batch-1',
       'Upload session session-1 cleaned up after abandonment (pre-migration rows)',
+      'interrupted_upload',
       'tx-cleanup'
     );
     expect(mocks.commitTransaction).toHaveBeenCalledWith('tx-cleanup');
     expect(mocks.rollbackTransaction).not.toHaveBeenCalled();
+  });
+
+  it('marks a session-owned batch move as interrupted_upload (not just the pre-migration fallback)', async () => {
+    mocks.executeQuery
+      .mockResolvedValueOnce([{ FileID: 'file.csv', BatchID: 'batch-2' }]) // session-owned batches (SessionID = ?)
+      .mockResolvedValueOnce([]) // no pre-migration (NULL SessionID) rows in this scope
+      .mockResolvedValueOnce({ affectedRows: 1 }); // mark session cleaned up
+    mocks.moveTemporaryBatchToFailedMeasurements.mockResolvedValue(2);
+
+    const result = await cleanupOrphanedData('forestgeo_testing', {
+      sessionId: 'session-2',
+      schema: 'forestgeo_testing',
+      plotId: 7,
+      censusId: 9,
+      userId: 'mason',
+      state: UploadSessionState.ABANDONED,
+      fileId: 'file.csv',
+      totalChunks: 1,
+      uploadedChunks: 1,
+      processedBatches: 0,
+      totalBatches: 1,
+      lastHeartbeat: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date()
+    });
+
+    expect(result).toEqual({ temporaryDeleted: 2, failedDeleted: 2 });
+    expect(mocks.moveTemporaryBatchToFailedMeasurements).toHaveBeenCalledWith(
+      expect.any(Object),
+      'forestgeo_testing',
+      'file.csv',
+      'batch-2',
+      'Upload session session-2 cleaned up after abandonment',
+      'interrupted_upload',
+      'tx-cleanup'
+    );
   });
 
   it('rolls back the outer transaction when a batch move fails', async () => {

--- a/frontend/config/uploadsessiontracker.ts
+++ b/frontend/config/uploadsessiontracker.ts
@@ -709,6 +709,7 @@ export async function cleanupOrphanedData(schema: string, session: UploadSession
           fileId,
           batchId,
           `Upload session ${session.sessionId} cleaned up after abandonment`,
+          'interrupted_upload',
           transactionID ?? undefined
         );
         temporaryDeleted += movedRows;
@@ -764,6 +765,7 @@ export async function cleanupOrphanedData(schema: string, session: UploadSession
               fileId,
               batchId,
               `Upload session ${session.sessionId} cleaned up after abandonment (pre-migration rows)`,
+              'interrupted_upload',
               transactionID ?? undefined
             );
             temporaryDeleted += movedRows;

--- a/frontend/db/migrations/schema-contract-repair/2026-08-27-02-seed-validation-19.sql
+++ b/frontend/db/migrations/schema-contract-repair/2026-08-27-02-seed-validation-19.sql
@@ -20,9 +20,9 @@ BEGIN
 END;
 
 SET @id_conflict := (SELECT COUNT(*) FROM sitespecificvalidations
-                     WHERE ValidationID = 19 AND ProcedureName <> 'ValidatePlotCoordinateConsistency');
+                     WHERE ValidationID = 19 AND NOT (ProcedureName <=> 'ValidatePlotCoordinateConsistency'));
 SET @name_conflict := (SELECT COUNT(*) FROM sitespecificvalidations
-                       WHERE ProcedureName = 'ValidatePlotCoordinateConsistency' AND ValidationID <> 19);
+                       WHERE ProcedureName = 'ValidatePlotCoordinateConsistency' AND NOT (ValidationID <=> 19));
 SET @enabled_without_helper := (
   SELECT COUNT(*) FROM sitespecificvalidations
    WHERE ValidationID = 19

--- a/frontend/db/sql/tablestructures.sql
+++ b/frontend/db/sql/tablestructures.sql
@@ -907,7 +907,7 @@ values ('ingestion', 'MISSING_FIELD_TREETAG', 'Missing required field: TreeTag')
        ('ingestion', 'DUPLICATE_TAG_STEMTAG', 'Duplicate TreeTag/StemTag within upload batch'),
        ('ingestion', 'NEGATIVE_DBH', 'DBH must be non-negative'),
        ('ingestion', 'NEGATIVE_HOM', 'HOM must be non-negative'),
-       ('ingestion', 'INVALID_COORDINATE', 'Coordinate value is negative'),
+       ('ingestion', 'INVALID_COORDINATE', 'Coordinate value is outside the accepted or storable range'),
        ('ingestion', 'FIELD_TOO_LONG', 'One or more fields exceed column length limits'),
        ('ingestion', 'MISSING_MEASUREMENT_DATA', 'Missing measurement data'),
        ('ingestion', 'AMBIGUOUS_PREVIOUS_MATCH', 'Ambiguous previous census match'),

--- a/frontend/lib/batchfailuretransfer.test.ts
+++ b/frontend/lib/batchfailuretransfer.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { moveTemporaryBatchToFailedMeasurements } from './batchfailuretransfer';
+import { moveTemporaryBatchToFailedMeasurements, moveTemporarySubBatchesToFailedMeasurements } from './batchfailuretransfer';
 
 const ensureMeasurementErrorDefinition = vi.hoisted(() => vi.fn());
 
@@ -53,6 +53,33 @@ describe('moveTemporaryBatchToFailedMeasurements', () => {
 
     expect(connectionManager.rollbackTransaction).toHaveBeenCalledWith('tx-2');
     expect(connectionManager.commitTransaction).not.toHaveBeenCalled();
+  });
+
+  it('preserves the transfer error when rollback itself fails', async () => {
+    const connectionManager = {
+      beginTransaction: vi.fn().mockResolvedValue('tx-rollback-fails'),
+      executeQuery: vi.fn().mockRejectedValue(new Error('transfer failed')),
+      rollbackTransaction: vi.fn().mockRejectedValue(new Error('rollback failed'))
+    } as any;
+
+    await expect(
+      moveTemporaryBatchToFailedMeasurements(connectionManager, 'forestgeo_testing', 'file.csv', 'batch-rollback', 'failed', 'sql_exception')
+    ).rejects.toMatchObject({ message: 'transfer failed', rollbackError: expect.any(Error) });
+  });
+
+  it('escapes the original batch ID when finding sub-batches', async () => {
+    const connectionManager = {
+      executeQuery: vi
+        .fn()
+        .mockResolvedValueOnce([{ BatchID: 'batch_%__sub001' }])
+        .mockResolvedValueOnce([{ rowCount: 0 }])
+    } as any;
+
+    await moveTemporarySubBatchesToFailedMeasurements(connectionManager, 'forestgeo_testing', 'file.csv', 'batch_%', 'failed', 'sql_exception', 'outer-tx');
+
+    const [sql, params] = connectionManager.executeQuery.mock.calls[0];
+    expect(sql).toContain("ESCAPE '\\\\'");
+    expect(params).toEqual(['file.csv', 'batch\\_\\%\\_\\_sub%']);
   });
 
   it('reuses an existing transaction when one is provided', async () => {

--- a/frontend/lib/batchfailuretransfer.test.ts
+++ b/frontend/lib/batchfailuretransfer.test.ts
@@ -162,10 +162,12 @@ describe('moveTemporaryBatchToFailedMeasurements', () => {
   });
 
   /**
-   * The inverse proof: a reason that matches none of the interruption
-   * fragments in `INTERRUPTION_REASON_FRAGMENTS` — prose inference would
-   * default it to SQL_EXCEPTION — must still land as INTERRUPTED_UPLOAD when
-   * the caller declares that kind.
+   * The inverse proof: interruption wording no longer influences
+   * classification at all — reason-text inference for INTERRUPTED_UPLOAD was
+   * removed, so a reason carrying none of the old interruption wordings
+   * (indeed, one that matches no classifier pattern at all) must still land
+   * as INTERRUPTED_UPLOAD, because the explicit kind the caller declares is
+   * the only thing that decides.
    */
   it('maps interrupted_upload to INTERRUPTED_UPLOAD even when the wording matches no interruption fragment', async () => {
     const connectionManager = {

--- a/frontend/lib/batchfailuretransfer.test.ts
+++ b/frontend/lib/batchfailuretransfer.test.ts
@@ -30,7 +30,7 @@ describe('moveTemporaryBatchToFailedMeasurements', () => {
     } as any;
     ensureMeasurementErrorDefinition.mockResolvedValue(22);
 
-    const movedRows = await moveTemporaryBatchToFailedMeasurements(connectionManager, 'forestgeo_testing', 'file.csv', 'batch-1', 'failed');
+    const movedRows = await moveTemporaryBatchToFailedMeasurements(connectionManager, 'forestgeo_testing', 'file.csv', 'batch-1', 'failed', 'sql_exception');
 
     expect(movedRows).toBe(1);
     expect(ensureMeasurementErrorDefinition).toHaveBeenCalledTimes(1);
@@ -47,9 +47,9 @@ describe('moveTemporaryBatchToFailedMeasurements', () => {
       rollbackTransaction: vi.fn().mockResolvedValue(undefined)
     } as any;
 
-    await expect(moveTemporaryBatchToFailedMeasurements(connectionManager, 'forestgeo_testing', 'file.csv', 'batch-2', 'failed')).rejects.toThrow(
-      'select failed'
-    );
+    await expect(
+      moveTemporaryBatchToFailedMeasurements(connectionManager, 'forestgeo_testing', 'file.csv', 'batch-2', 'failed', 'sql_exception')
+    ).rejects.toThrow('select failed');
 
     expect(connectionManager.rollbackTransaction).toHaveBeenCalledWith('tx-2');
     expect(connectionManager.commitTransaction).not.toHaveBeenCalled();
@@ -69,7 +69,15 @@ describe('moveTemporaryBatchToFailedMeasurements', () => {
     } as any;
     ensureMeasurementErrorDefinition.mockResolvedValue(22);
 
-    const movedRows = await moveTemporaryBatchToFailedMeasurements(connectionManager, 'forestgeo_testing', 'file.csv', 'batch-3', 'failed', 'outer-tx');
+    const movedRows = await moveTemporaryBatchToFailedMeasurements(
+      connectionManager,
+      'forestgeo_testing',
+      'file.csv',
+      'batch-3',
+      'failed',
+      'sql_exception',
+      'outer-tx'
+    );
 
     expect(movedRows).toBe(1);
     expect(connectionManager.beginTransaction).not.toHaveBeenCalled();
@@ -104,7 +112,8 @@ describe('moveTemporaryBatchToFailedMeasurements', () => {
       'forestgeo_harvard',
       'harvard2014b.TXT',
       'batch-interrupted',
-      INTERRUPTION_REASON
+      INTERRUPTION_REASON,
+      'interrupted_upload'
     );
 
     expect(movedRows).toBe(3);
@@ -116,6 +125,73 @@ describe('moveTemporaryBatchToFailedMeasurements', () => {
     expect(errorCode).toBe('INTERRUPTED_UPLOAD');
     expect(errorCode).not.toBe('SQL_EXCEPTION');
     expect(String(errorMessage).toLowerCase()).toContain('interrupted');
+  });
+
+  /**
+   * Every system-failure caller now declares its kind explicitly at the call
+   * site, so the code recorded must follow the declared kind — never a guess
+   * derived from the reason wording. This reason string contains no SQL
+   * keyword at all; prose inference would default it to SQL_EXCEPTION anyway
+   * here, but the point is that the classifier never even looks.
+   */
+  it('selects the error code from the explicit failure kind, not the message wording', async () => {
+    const connectionManager = {
+      beginTransaction: vi.fn().mockResolvedValue('tx-kind-sql'),
+      executeQuery: vi
+        .fn()
+        .mockResolvedValueOnce([{ rowCount: 3 }])
+        .mockResolvedValueOnce({ affectedRows: 3 })
+        .mockResolvedValueOnce({ affectedRows: 3 })
+        .mockResolvedValueOnce({ affectedRows: 3 }),
+      commitTransaction: vi.fn().mockResolvedValue(undefined),
+      rollbackTransaction: vi.fn().mockResolvedValue(undefined)
+    } as any;
+    ensureMeasurementErrorDefinition.mockResolvedValue(41);
+
+    await moveTemporaryBatchToFailedMeasurements(
+      connectionManager,
+      'forestgeo_testing',
+      'f.csv',
+      'batch-kind-sql',
+      'Sub-batch moved after all 5 attempts failed', // contains no SQL keyword
+      'sql_exception'
+    );
+
+    const [, , , errorCode] = ensureMeasurementErrorDefinition.mock.calls[0];
+    expect(errorCode).toBe('SQL_EXCEPTION');
+  });
+
+  /**
+   * The inverse proof: a reason that matches none of the interruption
+   * fragments in `INTERRUPTION_REASON_FRAGMENTS` — prose inference would
+   * default it to SQL_EXCEPTION — must still land as INTERRUPTED_UPLOAD when
+   * the caller declares that kind.
+   */
+  it('maps interrupted_upload to INTERRUPTED_UPLOAD even when the wording matches no interruption fragment', async () => {
+    const connectionManager = {
+      beginTransaction: vi.fn().mockResolvedValue('tx-kind-interrupted'),
+      executeQuery: vi
+        .fn()
+        .mockResolvedValueOnce([{ rowCount: 1 }])
+        .mockResolvedValueOnce({ affectedRows: 1 })
+        .mockResolvedValueOnce({ affectedRows: 1 })
+        .mockResolvedValueOnce({ affectedRows: 1 }),
+      commitTransaction: vi.fn().mockResolvedValue(undefined),
+      rollbackTransaction: vi.fn().mockResolvedValue(undefined)
+    } as any;
+    ensureMeasurementErrorDefinition.mockResolvedValue(42);
+
+    await moveTemporaryBatchToFailedMeasurements(
+      connectionManager,
+      'forestgeo_testing',
+      'f.csv',
+      'batch-kind-interrupted',
+      'Something completely unrelated happened during cleanup',
+      'interrupted_upload'
+    );
+
+    const [, , , errorCode] = ensureMeasurementErrorDefinition.mock.calls[0];
+    expect(errorCode).toBe('INTERRUPTED_UPLOAD');
   });
 
   /**
@@ -145,7 +221,7 @@ describe('moveTemporaryBatchToFailedMeasurements', () => {
     } as any;
     ensureMeasurementErrorDefinition.mockResolvedValue(22);
 
-    await moveTemporaryBatchToFailedMeasurements(connectionManager, 'forestgeo_testing', 'file.csv', 'batch-plot', 'failed');
+    await moveTemporaryBatchToFailedMeasurements(connectionManager, 'forestgeo_testing', 'file.csv', 'batch-plot', 'failed', 'sql_exception');
 
     const insertCall = connectionManager.executeQuery.mock.calls.find(
       (call: any[]) => String(call[0]).includes('INSERT INTO') && String(call[0]).includes('coremeasurements')

--- a/frontend/lib/batchfailuretransfer.ts
+++ b/frontend/lib/batchfailuretransfer.ts
@@ -1,5 +1,11 @@
 import ConnectionManager from '@/lib/db/connectionmanager';
-import { ensureMeasurementErrorDefinition, getIngestionErrorMessage, inferIngestionErrorCode, INGESTION_ERROR_SOURCE } from '@/config/measurementerrors';
+import {
+  ensureMeasurementErrorDefinition,
+  errorCodeForSystemFailure,
+  getIngestionErrorMessage,
+  INGESTION_ERROR_SOURCE,
+  type SystemFailureKind
+} from '@/config/measurementerrors';
 import { safeFormatQuery } from '@/lib/db/sqlsecurity';
 
 /**
@@ -13,6 +19,7 @@ export async function moveTemporarySubBatchesToFailedMeasurements(
   fileID: string,
   subBatchPrefix: string,
   failureReason: string,
+  failureKind: SystemFailureKind,
   transactionID?: string
 ): Promise<number> {
   const findSubBatchesSQL = safeFormatQuery(schema, 'SELECT DISTINCT BatchID FROM ??.temporarymeasurements WHERE FileID = ? AND BatchID LIKE ?');
@@ -21,7 +28,7 @@ export async function moveTemporarySubBatchesToFailedMeasurements(
 
   let totalMoved = 0;
   for (const row of subBatchRows) {
-    const moved = await moveTemporaryBatchToFailedMeasurements(connectionManager, schema, fileID, row.BatchID, failureReason, transactionID);
+    const moved = await moveTemporaryBatchToFailedMeasurements(connectionManager, schema, fileID, row.BatchID, failureReason, failureKind, transactionID);
     totalMoved += moved;
   }
   return totalMoved;
@@ -33,6 +40,7 @@ export async function moveTemporaryBatchToFailedMeasurements(
   fileID: string,
   batchID: string,
   failureReason: string,
+  failureKind: SystemFailureKind,
   transactionID?: string
 ): Promise<number> {
   const managesOwnTransaction = !transactionID;
@@ -48,7 +56,7 @@ export async function moveTemporaryBatchToFailedMeasurements(
     const sourceRowCount = Number(countRows?.[0]?.rowCount ?? 0);
 
     if (sourceRowCount > 0) {
-      const errorCode = inferIngestionErrorCode(failureReason);
+      const errorCode = errorCodeForSystemFailure(failureKind);
       const errorID = await ensureMeasurementErrorDefinition(
         connectionManager,
         schema,

--- a/frontend/lib/batchfailuretransfer.ts
+++ b/frontend/lib/batchfailuretransfer.ts
@@ -7,9 +7,10 @@ import {
   type SystemFailureKind
 } from '@/config/measurementerrors';
 import { safeFormatQuery } from '@/lib/db/sqlsecurity';
+import { buildSubBatchPattern, LIKE_ESCAPE_CLAUSE } from '@/lib/uploads/batch-family';
 
 /**
- * Moves all remaining sub-batches (BatchID LIKE 'prefix%') for a given file
+ * Moves all remaining sub-batches for a given file
  * to unresolved coremeasurements. Used when the client calls setupbulkfailure
  * with the original batchID but rows have been split into sub-batch IDs.
  */
@@ -17,21 +18,62 @@ export async function moveTemporarySubBatchesToFailedMeasurements(
   connectionManager: ConnectionManager,
   schema: string,
   fileID: string,
-  subBatchPrefix: string,
+  originalBatchID: string,
   failureReason: string,
   failureKind: SystemFailureKind,
   transactionID?: string
 ): Promise<number> {
-  const findSubBatchesSQL = safeFormatQuery(schema, 'SELECT DISTINCT BatchID FROM ??.temporarymeasurements WHERE FileID = ? AND BatchID LIKE ?');
-  // Reuse the caller's transaction when provided so multi-batch cleanup can stay atomic.
-  const subBatchRows: any[] = await connectionManager.executeQuery(findSubBatchesSQL, [fileID, `${subBatchPrefix}%`], transactionID);
+  const managesOwnTransaction = !transactionID;
+  let activeTransactionID = transactionID ?? null;
 
-  let totalMoved = 0;
-  for (const row of subBatchRows) {
-    const moved = await moveTemporaryBatchToFailedMeasurements(connectionManager, schema, fileID, row.BatchID, failureReason, failureKind, transactionID);
-    totalMoved += moved;
+  try {
+    if (managesOwnTransaction) {
+      activeTransactionID = await connectionManager.beginTransaction();
+    }
+
+    const findSubBatchesSQL = safeFormatQuery(
+      schema,
+      `SELECT DISTINCT BatchID
+       FROM ??.temporarymeasurements
+      WHERE FileID = ?
+        AND BatchID LIKE ? ${LIKE_ESCAPE_CLAUSE}`
+    );
+    // Reuse the caller's transaction when provided so multi-batch cleanup can stay atomic.
+    const subBatchRows: any[] = await connectionManager.executeQuery(
+      findSubBatchesSQL,
+      [fileID, buildSubBatchPattern(originalBatchID)],
+      activeTransactionID ?? undefined
+    );
+
+    let totalMoved = 0;
+    for (const row of subBatchRows) {
+      const moved = await moveTemporaryBatchToFailedMeasurements(
+        connectionManager,
+        schema,
+        fileID,
+        row.BatchID,
+        failureReason,
+        failureKind,
+        activeTransactionID ?? undefined
+      );
+      totalMoved += moved;
+    }
+    if (managesOwnTransaction && activeTransactionID) {
+      await connectionManager.commitTransaction(activeTransactionID);
+    }
+    return totalMoved;
+  } catch (error) {
+    if (managesOwnTransaction && activeTransactionID) {
+      try {
+        await connectionManager.rollbackTransaction(activeTransactionID);
+      } catch (rollbackError) {
+        if (error instanceof Error) {
+          (error as Error & { rollbackError?: unknown }).rollbackError = rollbackError;
+        }
+      }
+    }
+    throw error;
   }
-  return totalMoved;
 }
 
 export async function moveTemporaryBatchToFailedMeasurements(
@@ -102,6 +144,10 @@ export async function moveTemporaryBatchToFailedMeasurements(
         `INSERT IGNORE INTO ??.measurement_error_log (MeasurementID, ErrorID, IsResolved, CreatedAt, ResolvedAt)
          SELECT cm.CoreMeasurementID, ?, FALSE, NOW(), NULL
          FROM ??.coremeasurements cm
+         JOIN ??.temporarymeasurements tm
+           ON tm.id = cm.SourceRowIndex
+          AND tm.FileID = cm.UploadFileID
+          AND tm.BatchID = cm.UploadBatchID
          WHERE cm.UploadFileID = ?
            AND cm.UploadBatchID = ?
            AND cm.StemGUID IS NULL`
@@ -118,7 +164,15 @@ export async function moveTemporaryBatchToFailedMeasurements(
     return sourceRowCount;
   } catch (error) {
     if (managesOwnTransaction && activeTransactionID) {
-      await connectionManager.rollbackTransaction(activeTransactionID);
+      try {
+        await connectionManager.rollbackTransaction(activeTransactionID);
+      } catch (rollbackError) {
+        // Keep the actionable transfer error as the thrown error. The rollback
+        // failure is secondary, but attach it for structured diagnostics.
+        if (error instanceof Error) {
+          (error as Error & { rollbackError?: unknown }).rollbackError = rollbackError;
+        }
+      }
     }
     throw error;
   }

--- a/frontend/lib/uploads/ingest-batch.ts
+++ b/frontend/lib/uploads/ingest-batch.ts
@@ -29,6 +29,7 @@ import ailogger from '@/ailogger';
 import { safeFormatQuery } from '@/lib/db/sqlsecurity';
 import { shouldRecoverFailedInitialCensus } from '@/lib/failedinitialcensusrecovery';
 import { moveTemporaryBatchToFailedMeasurements } from '@/lib/batchfailuretransfer';
+import type { SystemFailureKind } from '@/config/measurementerrors';
 import { buildSubBatchID, buildSubBatchPattern, discoverBatchFamily, highestSubBatchOrdinal, LIKE_ESCAPE_CLAUSE } from '@/lib/uploads/batch-family';
 import { isKilledConnectionError, isKilledStatementError, QueryTimeoutError } from '@/lib/db/primitives';
 
@@ -585,7 +586,14 @@ async function processSubBatch(
     : `all ${MAX_ATTEMPTS_PER_SUBBATCH} attempts failed`;
 
   ailogger.error(`Sub-batch ${subBatchID} giving up: ${attemptSummary}`);
-  const movedRows = await moveTemporaryBatchToFailedMeasurements(connectionManager, schema, fileID, subBatchID, `Sub-batch moved after ${attemptSummary}`);
+  const movedRows = await moveTemporaryBatchToFailedMeasurements(
+    connectionManager,
+    schema,
+    fileID,
+    subBatchID,
+    `Sub-batch moved after ${attemptSummary}`,
+    'sql_exception'
+  );
   ailogger.warn(`Moved ${movedRows} rows from sub-batch ${subBatchID} to unresolved coremeasurements (${attemptSummary})`);
 
   return {
@@ -727,6 +735,7 @@ export async function ingestBatch(connectionManager: ConnectionManager, params: 
       }
 
       const failureReason = isMidBatchAbort ? 'Batch cancelled before completion' : `Sub-batch abandoned after unrecoverable error: ${subError.message}`;
+      const failureKind: SystemFailureKind = isMidBatchAbort ? 'interrupted_upload' : 'sql_exception';
 
       // Move all remaining sub-batches in a single transaction so cleanup
       // is atomic — either every remaining sub-batch is moved to failures
@@ -741,6 +750,7 @@ export async function ingestBatch(connectionManager: ConnectionManager, params: 
             fileID,
             subBatchIDs[j],
             failureReason,
+            failureKind,
             cleanupTransactionID
           );
           results.push({

--- a/frontend/lib/uploads/record-invalid-rows.test.ts
+++ b/frontend/lib/uploads/record-invalid-rows.test.ts
@@ -19,13 +19,9 @@ const { insertIngestionFailureRowsMock } = vi.hoisted(() => ({
   insertIngestionFailureRowsMock: vi.fn()
 }));
 
-vi.mock('@/config/measurementerrors', () => ({
-  insertIngestionFailureRows: insertIngestionFailureRowsMock,
-  toFiniteNumber: (value: unknown): number | null => {
-    if (value === null || value === undefined || (typeof value === 'string' && value.trim() === '')) return null;
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
+vi.mock('@/config/measurementerrors', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/config/measurementerrors')>()),
+  insertIngestionFailureRows: insertIngestionFailureRowsMock
 }));
 
 vi.mock('@/lib/db/connectionmanager', () => ({
@@ -93,6 +89,13 @@ describe('recordInvalidRows', () => {
     expect(rows[0].y).toBeNull();
     expect(rows[0].dbh).toBeNull();
     expect(rows[0].hom).toBeNull();
+  });
+
+  it('non-scalar, non-decimal, and out-of-range runtime values map to null', async () => {
+    await recordInvalidRows(makeConnectionManager(), BASE_CTX, [{ tag: 'T002b', lx: true, ly: [], px: '0x10', py: 1000000, dbh: {}, hom: '-1000000' } as any]);
+
+    const [row] = insertIngestionFailureRowsMock.mock.calls[0][2];
+    expect(row).toMatchObject({ x: null, y: null, plotX: null, plotY: null, dbh: null, hom: null });
   });
 
   it('valid numeric strings produce finite numbers', async () => {

--- a/frontend/lib/uploads/record-invalid-rows.test.ts
+++ b/frontend/lib/uploads/record-invalid-rows.test.ts
@@ -4,7 +4,7 @@
 // No real DB — insertIngestionFailureRows is mocked. The tests verify:
 //   - empty string → null for numeric fields ('' must not become 0 or NaN)
 //   - empty string → null for string fields (old-worker 'value || null' semantics)
-//   - missing / empty failureReason → 'Unknown parse error'
+//   - missing / empty failureReason passes through as null (choke point owns the fallback)
 //   - date formatting → 'YYYY-MM-DD'
 //   - sourceRowIndexOffset arithmetic (chunked callers must pass running offset)
 //   - recordFailedMeasurementRows passes per-row fileID/batchID overrides through
@@ -132,18 +132,18 @@ describe('recordInvalidRows', () => {
     expect(rows[1].plotY).toBeNull();
   });
 
-  it('missing failureReason defaults to "Unknown parse error"', async () => {
+  it('missing failureReason passes through as null', async () => {
     await recordInvalidRows(makeConnectionManager(), BASE_CTX, [{ tag: 'T004' }]);
 
     const rows = insertIngestionFailureRowsMock.mock.calls[0][2];
-    expect(rows[0].failureReason).toBe('Unknown parse error');
+    expect(rows[0].failureReason).toBeNull();
   });
 
-  it('empty-string failureReason defaults to "Unknown parse error"', async () => {
+  it('empty-string failureReason passes through as null', async () => {
     await recordInvalidRows(makeConnectionManager(), BASE_CTX, [{ tag: 'T005', failureReason: '' }]);
 
     const rows = insertIngestionFailureRowsMock.mock.calls[0][2];
-    expect(rows[0].failureReason).toBe('Unknown parse error');
+    expect(rows[0].failureReason).toBeNull();
   });
 
   it('present failureReason is preserved as-is', async () => {
@@ -271,5 +271,31 @@ describe('recordFailedMeasurementRows', () => {
 
     const [mapped] = insertIngestionFailureRowsMock.mock.calls[0][2];
     expect(mapped).toMatchObject({ x: 1.25, y: null, plotX: null, plotY: 0, dbh: null });
+  });
+
+  it('maps HTTP rejected-row comments from the wire field `comments`, not `description`', async () => {
+    insertIngestionFailureRowsMock.mockResolvedValue([1]);
+    await recordFailedMeasurementRows(
+      makeConnectionManager(),
+      'forestgeo_testing',
+      [{ comments: 'field note', failureReasons: 'reason text' } as any],
+      'f.csv',
+      'b1',
+      1,
+      2
+    );
+    const input = insertIngestionFailureRowsMock.mock.calls[0][2][0];
+    expect(input.comments).toBe('field note');
+    expect(input.failureReason).toBe('reason text');
+  });
+
+  it('missing comments and failureReasons pass through as null', async () => {
+    const rows = [{ tag: 'T070' } as any];
+
+    await recordFailedMeasurementRows(makeConnectionManager(), 'forestgeo_test', rows, 'f.csv', 'b-005', 1, 2);
+
+    const [mapped] = insertIngestionFailureRowsMock.mock.calls[0][2];
+    expect(mapped.comments).toBeNull();
+    expect(mapped.failureReason).toBeNull();
   });
 });

--- a/frontend/lib/uploads/record-invalid-rows.test.ts
+++ b/frontend/lib/uploads/record-invalid-rows.test.ts
@@ -220,7 +220,7 @@ describe('recordFailedMeasurementRows', () => {
     expect(insertIngestionFailureRowsMock).not.toHaveBeenCalled();
   });
 
-  it('per-row fileID/batchID overrides take precedence over caller-level defaults', async () => {
+  it('ignores per-row fileID/batchID overrides and uses caller-level identity', async () => {
     const rows = [
       { tag: 'T030', failureReasons: 'bad data', fileID: 'override-file.csv', batchID: 'override-batch' } as any,
       { tag: 'T031', failureReasons: 'wrong coords' } as any
@@ -229,10 +229,10 @@ describe('recordFailedMeasurementRows', () => {
     await recordFailedMeasurementRows(makeConnectionManager(), 'forestgeo_test', rows, 'default-file.csv', 'default-batch', 10, 20);
 
     const mapped = insertIngestionFailureRowsMock.mock.calls[0][2];
-    // Row 0 has per-row overrides — must win.
-    expect(mapped[0].fileID).toBe('override-file.csv');
-    expect(mapped[0].batchID).toBe('override-batch');
-    // Row 1 falls back to caller-level defaults.
+    // Row 0 cannot redirect the persistence boundary.
+    expect(mapped[0].fileID).toBe('default-file.csv');
+    expect(mapped[0].batchID).toBe('default-batch');
+    // Row 1 uses the same caller-level defaults.
     expect(mapped[1].fileID).toBe('default-file.csv');
     expect(mapped[1].batchID).toBe('default-batch');
   });

--- a/frontend/lib/uploads/record-invalid-rows.ts
+++ b/frontend/lib/uploads/record-invalid-rows.ts
@@ -15,7 +15,7 @@
 
 import moment from 'moment/moment';
 import ConnectionManager from '@/lib/db/connectionmanager';
-import { insertIngestionFailureRows, toFiniteNumber } from '@/config/measurementerrors';
+import { insertIngestionFailureRows, normalizeFailureDescription, toFiniteNumber } from '@/config/measurementerrors';
 import { safeFormatQuery } from '@/lib/db/sqlsecurity';
 import { FileRow } from '@/config/macros/formdetails';
 import { FailedMeasurementsRDS } from '@/lib/db/definitions/core';
@@ -135,9 +135,13 @@ export async function recordFailedMeasurementRows(
     date: row.date ?? null,
     codes: row.codes ?? null,
     comments: row.comments ?? null,
-    failureReason: row.failureReasons ?? null,
-    fileID: row.fileID ?? fileID,
-    batchID: row.batchID ?? batchID,
+    failureReason:
+      row.failureReasons == null ? null : typeof row.failureReasons === 'string' ? row.failureReasons : normalizeFailureDescription(row.failureReasons),
+    // File and batch identity are server-owned. A client can include these
+    // fields in a DTO-shaped JSON row, but must not redirect persistence to a
+    // different upload family.
+    fileID,
+    batchID,
     sourceRowIndex: idx + 1
   }));
 

--- a/frontend/lib/uploads/record-invalid-rows.ts
+++ b/frontend/lib/uploads/record-invalid-rows.ts
@@ -54,8 +54,9 @@ export interface InvalidRowContext {
  *
  * Mirrors the mapping that the old async worker (insertInvalidMeasurementRows,
  * git e01cdb33) used before it was removed: lx→x, ly→y; date formatted as
- * YYYY-MM-DD via moment when present; failureReason defaulting to
- * "Unknown parse error" when absent.
+ * YYYY-MM-DD via moment when present; failureReason is passed through as-is
+ * (null when absent) — insertIngestionFailureRows (the persistence choke
+ * point) owns the fallback policy, not this caller.
  *
  * Returns the count of rows recorded (0 when rows is empty).
  */
@@ -84,7 +85,7 @@ export async function recordInvalidRows(
     date: row.date ? moment(row.date).format('YYYY-MM-DD') : null,
     codes: row.codes || null,
     comments: row.comments || null,
-    failureReason: row.failureReason ? String(row.failureReason) : 'Unknown parse error',
+    failureReason: row.failureReason ? String(row.failureReason) : null,
     fileID: ctx.fileName,
     batchID: ctx.batchID,
     sourceRowIndex: idx + 1 + offset
@@ -133,8 +134,8 @@ export async function recordFailedMeasurementRows(
     hom: toFiniteNumber(row.hom),
     date: row.date ?? null,
     codes: row.codes ?? null,
-    comments: row.description ?? null,
-    failureReason: row.failureReasons ?? 'Unknown error',
+    comments: row.comments ?? null,
+    failureReason: row.failureReasons ?? null,
     fileID: row.fileID ?? fileID,
     batchID: row.batchID ?? batchID,
     sourceRowIndex: idx + 1

--- a/frontend/scripts/deploy-validations-to-all-schemas.test.ts
+++ b/frontend/scripts/deploy-validations-to-all-schemas.test.ts
@@ -5,9 +5,14 @@
  * deployProceduresOnly / activateValidation19 against a real schema is
  * covered by tests/integration/deploy-validations.test.ts.
  */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { describe, expect, it, vi } from 'vitest';
 import type { Connection } from 'mysql2/promise';
-import { main, parseMode, withSchemaConnection, type DeployCliDeps } from './deploy-validations-to-all-schemas';
+import { main, parseMode, parseStoredProceduresSQL, withSchemaConnection, type DeployCliDeps } from './deploy-validations-to-all-schemas';
+
+const STORED_PROCEDURES_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'db', 'sql', 'storedprocedures.sql');
 
 function makeConnection(overrides: Partial<Connection> = {}): Connection {
   return {
@@ -43,6 +48,25 @@ describe('parseMode', () => {
 
   it.each([[['--procedures-only', '--activate-validation-19']], [['--unknown-mode']]])('rejects invalid CLI mode combinations synchronously: %j', args => {
     expect(() => parseMode(args)).toThrow(/mode|argument/i);
+  });
+});
+
+describe('parseStoredProceduresSQL', () => {
+  it('returns each leading DROP as a separate statement for multipleStatements=false connections', () => {
+    const statements = parseStoredProceduresSQL(fs.readFileSync(STORED_PROCEDURES_PATH, 'utf8'));
+    const firstCreate = statements.findIndex(statement => /^create\s+procedure/i.test(statement));
+    const leadingDrops = statements.slice(0, firstCreate);
+
+    expect(firstCreate).toBeGreaterThan(0);
+    expect(leadingDrops).toHaveLength(12);
+    for (const statement of leadingDrops) {
+      const executableSql = statement
+        .split('\n')
+        .filter(line => !line.trimStart().startsWith('--'))
+        .join('\n')
+        .trim();
+      expect(executableSql).toMatch(/^drop\s+procedure\s+if\s+exists\s+[^;]+$/i);
+    }
   });
 });
 
@@ -95,6 +119,33 @@ describe('main CLI dispatch', () => {
 
     expect(failingSchemaConn.end, 'a per-schema connection must close even when a later statement in the same schema fails').toHaveBeenCalledOnce();
     expect(discoveryConn.end).toHaveBeenCalledOnce();
+  });
+
+  it('reports a per-schema close failure alongside the primary deployment error', async () => {
+    const discoveryConn = makeConnection();
+    const failingSchemaConn = makeConnection({
+      query: vi.fn().mockRejectedValueOnce(new Error('routine DDL failed')),
+      end: vi.fn().mockRejectedValue(new Error('close failed')) as any
+    });
+    const deps = makeCliDeps({
+      readSqlFile: vi.fn().mockReturnValue('DROP PROCEDURE IF EXISTS example;'),
+      discoverSchemas: vi.fn().mockResolvedValue(['forestgeo_test']),
+      createConnection: vi.fn().mockResolvedValueOnce(discoveryConn).mockResolvedValueOnce(failingSchemaConn)
+    });
+
+    await expect(main(['--procedures-only'], deps)).rejects.toThrow(/failed for 1 schema/i);
+    expect(deps.log).toHaveBeenCalledWith('  FAILED: routine DDL failed (connection cleanup also failed: close failed)');
+  });
+
+  it('preserves a discovery failure when closing that connection also fails', async () => {
+    const discoveryConn = makeConnection({ end: vi.fn().mockRejectedValue(new Error('discovery close failed')) as any });
+    const deps = makeCliDeps({
+      createConnection: vi.fn().mockResolvedValue(discoveryConn),
+      discoverSchemas: vi.fn().mockRejectedValue(new Error('schema discovery failed'))
+    });
+
+    await expect(main(['--activate-validation-19'], deps)).rejects.toThrow('schema discovery failed');
+    expect(deps.log).toHaveBeenCalledWith('Discovery connection cleanup failed after schema discovery failed: discovery close failed');
   });
 });
 

--- a/frontend/scripts/deploy-validations-to-all-schemas.ts
+++ b/frontend/scripts/deploy-validations-to-all-schemas.ts
@@ -67,8 +67,10 @@ export interface SchemaResult {
  * Parse storedprocedures.sql into executable statements.
  *
  * The file uses MySQL client DELIMITER directives which mysql2 cannot handle
- * directly. We strip the DELIMITER lines, split on the custom delimiter ($$),
- * and return individual CREATE/DROP statements.
+ * directly. We strip the DELIMITER lines and return every statement
+ * individually, including the ordinary semicolon-delimited statements before
+ * and between stored procedure blocks. This keeps the output executable on
+ * the production connections, which deliberately disable multipleStatements.
  */
 export function parseStoredProceduresSQL(raw: string): string[] {
   const statements: string[] = [];
@@ -91,9 +93,11 @@ export function parseStoredProceduresSQL(raw: string): string[] {
 
     buffer += line + '\n';
 
-    // Check if the buffer ends with the current delimiter
+    // Check if the buffer ends with the current delimiter. This applies to the
+    // ordinary semicolon delimiter too; otherwise all leading DROP statements
+    // are bundled into one query that production mysql2 connections reject.
     const trimmedBuffer = buffer.trimEnd();
-    if (currentDelimiter !== ';' && trimmedBuffer.endsWith(currentDelimiter)) {
+    if (trimmedBuffer.endsWith(currentDelimiter)) {
       const stmt = trimmedBuffer.slice(0, -currentDelimiter.length).trim();
       if (stmt.length > 0) {
         statements.push(stmt);
@@ -102,16 +106,10 @@ export function parseStoredProceduresSQL(raw: string): string[] {
     }
   }
 
-  // Flush remaining buffer (handles trailing statements after final DELIMITER ;)
+  // Flush an unterminated trailing statement, if present.
   const remaining = buffer.trim();
-  if (remaining.length > 0) {
-    // Split on semicolons for any remaining simple statements
-    for (const part of remaining.split(';')) {
-      const stmt = part.trim();
-      if (stmt.length > 0 && !stmt.startsWith('--')) {
-        statements.push(stmt);
-      }
-    }
+  if (remaining.length > 0 && !remaining.startsWith('--')) {
+    statements.push(remaining);
   }
 
   return statements;
@@ -278,7 +276,7 @@ export async function withSchemaConnection<T>(
       // Preserve the actionable SQL failure. The close failure remains attached
       // for structured logging/debugging without replacing the primary error.
       if (operationError instanceof Error) {
-        (operationError as Error & { cleanupError?: unknown }).cleanupError = closeError;
+        (operationError as ErrorWithCleanup).cleanupError = closeError;
       }
     }
   }
@@ -382,9 +380,22 @@ interface SchemaSweepOptions<TPrepared> {
   processSchema: (schema: string, password: string, prepared: TPrepared) => Promise<string>;
 }
 
+type ErrorWithCleanup = Error & { cleanupError?: unknown };
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function describeErrorWithCleanup(error: unknown): string {
+  const primary = describeError(error);
+  const cleanupError = error instanceof Error ? (error as ErrorWithCleanup).cleanupError : undefined;
+  return cleanupError === undefined ? primary : `${primary} (connection cleanup also failed: ${describeError(cleanupError)})`;
+}
+
 /** Shared discovery/iteration/reporting lifecycle for every deployment mode. */
 async function runForAllSchemas<TPrepared = undefined>(deps: DeployCliDeps, password: string, options: SchemaSweepOptions<TPrepared>): Promise<void> {
   const discoveryConnection = await deps.createConnection(discoveryConnectionOptions(password));
+  let operationError: unknown;
   try {
     deps.log('[Step 1] Finding all ForestGEO schemas...');
     const schemas = await deps.discoverSchemas(discoveryConnection);
@@ -418,8 +429,8 @@ async function runForAllSchemas<TPrepared = undefined>(deps: DeployCliDeps, pass
         const detail = await options.processSchema(schema, password, prepared);
         deps.log(`  OK - ${detail}`);
         results.push({ schema, status: 'deployed', detail });
-      } catch (error: any) {
-        const detail = error instanceof Error ? error.message : String(error);
+      } catch (error: unknown) {
+        const detail = describeErrorWithCleanup(error);
         deps.log(`  FAILED: ${detail}`);
         results.push({ schema, status: 'failed', detail });
       }
@@ -427,8 +438,19 @@ async function runForAllSchemas<TPrepared = undefined>(deps: DeployCliDeps, pass
     }
 
     reportSummary(deps, options.summaryTitle, results, schemas.length);
+  } catch (error: unknown) {
+    operationError = error;
+    throw error;
   } finally {
-    await discoveryConnection.end();
+    try {
+      await discoveryConnection.end();
+    } catch (closeError: unknown) {
+      if (operationError === undefined) throw closeError;
+      if (operationError instanceof Error) {
+        (operationError as ErrorWithCleanup).cleanupError = closeError;
+      }
+      deps.log(`Discovery connection cleanup failed after ${describeError(operationError)}: ${describeError(closeError)}`);
+    }
   }
 }
 

--- a/frontend/scripts/deploy-validations-to-all-schemas.ts
+++ b/frontend/scripts/deploy-validations-to-all-schemas.ts
@@ -306,10 +306,10 @@ async function discoverForestGeoSchemas(conn: mysql.Connection): Promise<string[
   const [rows] = await conn.query<mysql.RowDataPacket[]>(
     `SELECT SCHEMA_NAME as schema_name
        FROM INFORMATION_SCHEMA.SCHEMATA
-      WHERE SCHEMA_NAME LIKE 'forestgeo_%'
+      WHERE SCHEMA_NAME LIKE 'forestgeo\\_%' ESCAPE '\\\\'
       ORDER BY SCHEMA_NAME`
   );
-  return rows.map((r: any) => String(r.schema_name));
+  return rows.map((r: any) => String(r.schema_name)).filter(schema => /^forestgeo_[a-z0-9_]+$/.test(schema));
 }
 
 export const realDeps: DeployCliDeps = {

--- a/frontend/scripts/seed-serc-metadata.ts
+++ b/frontend/scripts/seed-serc-metadata.ts
@@ -347,7 +347,7 @@ async function seedMeasurementErrors(conn: mysql.Connection): Promise<void> {
     ['ingestion', 'DUPLICATE_ENTRY', 'Duplicate measurement row detected'],
     ['ingestion', 'NEGATIVE_DBH', 'DBH must be non-negative'],
     ['ingestion', 'NEGATIVE_HOM', 'HOM must be non-negative'],
-    ['ingestion', 'INVALID_COORDINATE', 'Coordinate value is negative'],
+    ['ingestion', 'INVALID_COORDINATE', 'Coordinate value is outside the accepted or storable range'],
     ['ingestion', 'FIELD_TOO_LONG', 'One or more fields exceed column length limits'],
     ['ingestion', 'MISSING_MEASUREMENT_DATA', 'Missing measurement data'],
     ['ingestion', 'QUADRAT_MISMATCH', 'Quadrat mismatch across censuses'],

--- a/frontend/tests/integration/deploy-validations.test.ts
+++ b/frontend/tests/integration/deploy-validations.test.ts
@@ -26,6 +26,7 @@
  */
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import fs from 'fs';
+import mysql from 'mysql2/promise';
 import path from 'path';
 import type { Connection, RowDataPacket } from 'mysql2/promise';
 import { setupTestDatabase, teardownTestDatabase, type TestDatabaseConfig } from '../setup/local-db-setup';
@@ -115,6 +116,15 @@ describe('deploy-validations-to-all-schemas — integration', () => {
   // -------------------------------------------------------------------------
 
   describe('deployProceduresOnly', () => {
+    it('executes the parsed source through the production multipleStatements=false setting', async () => {
+      const productionLikeConnection = await mysql.createConnection({ ...config, multipleStatements: false });
+      try {
+        await deployProceduresOnly(productionLikeConnection, schema, procedureStatements);
+      } finally {
+        await productionLikeConnection.end();
+      }
+    }, 60000);
+
     it('preserves every custom validation row and every pre-existing IsEnabled value', async () => {
       await connection.query(
         `INSERT INTO sitespecificvalidations (ValidationID, ProcedureName, Description, Criteria, Definition, ChangelogDefinition, IsEnabled)

--- a/frontend/tests/integration/editplan-writer-failedmeasurements.integration.test.ts
+++ b/frontend/tests/integration/editplan-writer-failedmeasurements.integration.test.ts
@@ -196,7 +196,7 @@ async function loadCoreMeasurement(connection: Connection, coreMeasurementID: nu
 
 async function loadErrorLogRows(connection: Connection, coreMeasurementID: number): Promise<RowDataPacket[]> {
   const [rows] = await connection.query<RowDataPacket[]>(
-    `SELECT mel.MeasurementID, mel.ErrorID, mel.IsResolved, me.ErrorSource, me.ErrorCode
+    `SELECT mel.MeasurementID, mel.ErrorID, mel.IsResolved, me.ErrorSource, me.ErrorCode, me.ErrorMessage
      FROM measurement_error_log mel
      JOIN measurement_errors me ON me.ErrorID = mel.ErrorID
      WHERE mel.MeasurementID = ?
@@ -360,6 +360,69 @@ describe('writeFailedMeasurements (integration)', () => {
       const afterStoredDateAsIso =
         afterStoredDate instanceof Date ? afterStoredDate.toISOString().split('T')[0] : String(afterStoredDate).split('T')[0].split(' ')[0];
       expect(afterStoredDateAsIso).toBe(NEW_DATE_YMD);
+    });
+  });
+
+  describe('Description is the reject reason, not a copy of the comments', () => {
+    // The legacy PATCH wrote Comments into both RawComments and Description.
+    // Any edit of an unresolved row therefore overwrote the recorded reject
+    // reason with the user's comment text. Revalidation masks this whenever it
+    // still finds errors (it restates Description afterwards), so the case that
+    // actually loses data is the corrected row: revalidation returns nothing,
+    // and the first write is the final value.
+    const NEW_COMMENT = 'researcher note added during triage';
+
+    it('clears Description rather than stamping the comment on it once the row revalidates clean', async () => {
+      const validSpeciesCode = testData.species[0].SpeciesCode;
+      const validQuadratName = testData.quadrats[0].QuadratName;
+      const newValues = {
+        SpCode: validSpeciesCode,
+        Quadrat: validQuadratName,
+        Comments: NEW_COMMENT
+      };
+      const plan = buildPlan(
+        [
+          { field: 'SpCode', from: INITIAL_RAW_SPCODE, to: validSpeciesCode },
+          { field: 'Quadrat', from: INITIAL_RAW_QUADRAT, to: validQuadratName },
+          { field: 'Comments', from: INITIAL_RAW_COMMENTS, to: NEW_COMMENT }
+        ],
+        fixture.coreMeasurementID
+      );
+      const input = buildInput(config.database, fixture.plotID, fixture.censusID, fixture.coreMeasurementID, newValues);
+
+      const txID = await cm.beginTransaction();
+      await writeFailedMeasurements(cm, { ...input, transactionID: txID }, plan, txID);
+      await cm.commitTransaction(txID);
+
+      // Precondition for this test to mean anything: the row must revalidate
+      // clean, so nothing restates Description after the first write.
+      const unresolvedAfter = (await loadErrorLogRows(connection, fixture.coreMeasurementID)).filter(row => Number(row.IsResolved) === 0);
+      expect(unresolvedAfter).toHaveLength(0);
+
+      const afterCm = await loadCoreMeasurement(connection, fixture.coreMeasurementID);
+      expect(afterCm.RawComments).toBe(NEW_COMMENT);
+      expect(afterCm.Description).toBeNull();
+    });
+
+    it('restates Description from the revalidation errors, never from the comment, while the row is still defective', async () => {
+      const plan = buildPlan([{ field: 'Comments', from: INITIAL_RAW_COMMENTS, to: NEW_COMMENT }], fixture.coreMeasurementID);
+      const input = buildInput(config.database, fixture.plotID, fixture.censusID, fixture.coreMeasurementID, { Comments: NEW_COMMENT });
+
+      const txID = await cm.beginTransaction();
+      await writeFailedMeasurements(cm, { ...input, transactionID: txID }, plan, txID);
+      await cm.commitTransaction(txID);
+
+      const unresolvedMessages = (await loadErrorLogRows(connection, fixture.coreMeasurementID))
+        .filter(row => Number(row.IsResolved) === 0)
+        .map(row => String(row.ErrorMessage));
+      expect(unresolvedMessages.length).toBeGreaterThan(0);
+
+      const afterCm = await loadCoreMeasurement(connection, fixture.coreMeasurementID);
+      expect(afterCm.RawComments).toBe(NEW_COMMENT);
+      expect(afterCm.Description).not.toBe(NEW_COMMENT);
+      for (const message of unresolvedMessages) {
+        expect(String(afterCm.Description)).toContain(message);
+      }
     });
   });
 

--- a/frontend/tests/integration/editplan-writer-measurementssummary.integration.test.ts
+++ b/frontend/tests/integration/editplan-writer-measurementssummary.integration.test.ts
@@ -396,6 +396,76 @@ describe('writeMeasurementsSummary (integration)', () => {
     });
   });
 
+  describe('StemPlotX / StemPlotY change', () => {
+    it('propagates plot coordinates to the stems row and stamps RawPlotX/RawPlotY on the measurement', async () => {
+      // Negative on one axis on purpose: signed plot coordinates are valid
+      // data (a stem west of the plot origin) and must survive the writer.
+      const NEW_PLOT_X = -2.531244;
+      const NEW_PLOT_Y = 487.125;
+      const stemGUIDBefore = fixture.stemGUIDs[STEM_TAG_S1];
+
+      const plan = buildPlan(
+        [
+          { field: 'StemPlotX', from: null, to: NEW_PLOT_X },
+          { field: 'StemPlotY', from: null, to: NEW_PLOT_Y }
+        ],
+        fixture.coreMeasurementID
+      );
+      const input = buildInput(config.database, fixture.plotID, fixture.censusID, fixture.coreMeasurementID, {
+        StemPlotX: NEW_PLOT_X,
+        StemPlotY: NEW_PLOT_Y
+      });
+
+      const txID = await cm.beginTransaction();
+      await writeMeasurementsSummary(cm, { ...input, transactionID: txID }, plan, txID);
+      await cm.commitTransaction(txID);
+
+      const stemRow = await loadStem(connection, stemGUIDBefore);
+      expect(Number(stemRow?.PlotX)).toBeCloseTo(NEW_PLOT_X, 6);
+      expect(Number(stemRow?.PlotY)).toBeCloseTo(NEW_PLOT_Y, 6);
+      // Local coordinates are a separate axis pair and must not move.
+      expect(Number(stemRow?.LocalX)).toBeCloseTo(INITIAL_STEM_X, 2);
+      expect(Number(stemRow?.LocalY)).toBeCloseTo(INITIAL_STEM_Y, 2);
+
+      // The row-level snapshot must reflect the edit so the
+      // COALESCE(RawPlotX, PlotX) read model shows the corrected value and
+      // validation 19 (raw axes only) sees it.
+      const cmRow = await loadCoreMeasurement(connection, fixture.coreMeasurementID);
+      expect(Number(cmRow.RawPlotX)).toBeCloseTo(NEW_PLOT_X, 6);
+      expect(Number(cmRow.RawPlotY)).toBeCloseTo(NEW_PLOT_Y, 6);
+      expect(cmRow.IsValidated).toBeNull();
+    });
+
+    it('does NOT fabricate RawPlotX/RawPlotY when an unrelated raw-sync edit runs', async () => {
+      // Give the stem canonical plot coordinates while the measurement row's
+      // raw columns stay NULL — the shape of a row whose upload file never
+      // supplied px/py on a stem that got coordinates from another row.
+      const stemGUID = fixture.stemGUIDs[STEM_TAG_S1];
+      await connection.query('UPDATE stems SET PlotX = ?, PlotY = ? WHERE StemGUID = ?', [100.5, 200.25, stemGUID]);
+
+      // StemLocalX is a raw-sync trigger field, so this edit rewrites the Raw*
+      // columns. RawPlotX/RawPlotY must stay NULL: stamping the stem's
+      // canonical value would fabricate an "as uploaded" plot coordinate and
+      // enroll this row in raw-axes-only validation 19.
+      const NEW_X = 9.25;
+      const plan = buildPlan([{ field: 'StemLocalX', from: INITIAL_STEM_X, to: NEW_X }], fixture.coreMeasurementID);
+      const input = buildInput(config.database, fixture.plotID, fixture.censusID, fixture.coreMeasurementID, { StemLocalX: NEW_X });
+
+      const txID = await cm.beginTransaction();
+      await writeMeasurementsSummary(cm, { ...input, transactionID: txID }, plan, txID);
+      await cm.commitTransaction(txID);
+
+      const cmRow = await loadCoreMeasurement(connection, fixture.coreMeasurementID);
+      expect(cmRow.RawX).not.toBeNull();
+      expect(cmRow.RawPlotX).toBeNull();
+      expect(cmRow.RawPlotY).toBeNull();
+
+      const stemRow = await loadStem(connection, stemGUID);
+      expect(Number(stemRow?.PlotX)).toBeCloseTo(100.5, 2);
+      expect(Number(stemRow?.PlotY)).toBeCloseTo(200.25, 2);
+    });
+  });
+
   describe('StemTag change', () => {
     it('creates a new stem on the same tree/quadrat and rewires the measurement', async () => {
       const newStemTag = 'WS9';

--- a/frontend/tests/integration/editplan-writer-measurementssummary.integration.test.ts
+++ b/frontend/tests/integration/editplan-writer-measurementssummary.integration.test.ts
@@ -436,6 +436,32 @@ describe('writeMeasurementsSummary (integration)', () => {
       expect(cmRow.IsValidated).toBeNull();
     });
 
+    it('preserves the canonical Y axis when only X changes and the row raw Y disagrees', async () => {
+      const stemGUID = fixture.stemGUIDs[STEM_TAG_S1];
+      const CANONICAL_X = 10.25;
+      const CANONICAL_Y = 20.5;
+      const RAW_X = 110.25;
+      const RAW_Y = 220.5;
+      const NEW_X = -15.125001;
+      await connection.query('UPDATE stems SET PlotX = ?, PlotY = ? WHERE StemGUID = ?', [CANONICAL_X, CANONICAL_Y, stemGUID]);
+      await connection.query('UPDATE coremeasurements SET RawPlotX = ?, RawPlotY = ? WHERE CoreMeasurementID = ?', [RAW_X, RAW_Y, fixture.coreMeasurementID]);
+
+      const plan = buildPlan([{ field: 'StemPlotX', from: RAW_X, to: NEW_X }], fixture.coreMeasurementID);
+      const input = buildInput(config.database, fixture.plotID, fixture.censusID, fixture.coreMeasurementID, { StemPlotX: NEW_X });
+
+      const txID = await cm.beginTransaction();
+      await writeMeasurementsSummary(cm, { ...input, transactionID: txID }, plan, txID);
+      await cm.commitTransaction(txID);
+
+      const stemRow = await loadStem(connection, stemGUID);
+      expect(Number(stemRow?.PlotX)).toBeCloseTo(NEW_X, 6);
+      expect(Number(stemRow?.PlotY), 'an X-only edit must not copy the row-level RawPlotY over the canonical stem Y').toBeCloseTo(CANONICAL_Y, 6);
+
+      const cmRow = await loadCoreMeasurement(connection, fixture.coreMeasurementID);
+      expect(Number(cmRow.RawPlotX)).toBeCloseTo(NEW_X, 6);
+      expect(Number(cmRow.RawPlotY), 'the untouched raw snapshot axis must also remain unchanged').toBeCloseTo(RAW_Y, 6);
+    });
+
     it('does NOT fabricate RawPlotX/RawPlotY when an unrelated raw-sync edit runs', async () => {
       // Give the stem canonical plot coordinates while the measurement row's
       // raw columns stay NULL — the shape of a row whose upload file never

--- a/frontend/tests/integration/ingest-batch.test.ts
+++ b/frontend/tests/integration/ingest-batch.test.ts
@@ -282,6 +282,20 @@ describe('ingestBatch — integration', () => {
     return rows;
   }
 
+  /** Distinct ingestion error codes currently attached to this file's unresolved rows. */
+  async function fetchIngestionErrorCodes(fileName: string = FILE_NAME): Promise<string[]> {
+    const [rows] = await connection.query<RowDataPacket[]>(
+      `SELECT DISTINCT me.ErrorCode
+       FROM measurement_error_log mel
+       JOIN measurement_errors me ON me.ErrorID = mel.ErrorID
+       JOIN coremeasurements cm ON cm.CoreMeasurementID = mel.MeasurementID
+       WHERE cm.UploadFileID = ? AND me.ErrorSource = 'ingestion'
+       ORDER BY me.ErrorCode`,
+      [fileName]
+    );
+    return rows.map(row => String(row.ErrorCode));
+  }
+
   async function countTemporaryRows(): Promise<number> {
     const [rows] = await connection.query<RowDataPacket[]>('SELECT COUNT(*) AS count FROM temporarymeasurements WHERE FileID = ? AND BatchID = ?', [
       FILE_NAME,
@@ -576,6 +590,13 @@ describe('ingestBatch — integration', () => {
     );
     console.log(`[abort-mid] unresolved coremeasurements rows=${unresolvedRows[0].count}`);
     expect(Number(unresolvedRows[0].count)).toBe(EXPECTED_ROW_COUNT);
+
+    // A mid-retry abort is an interruption, not a data defect — the row was
+    // never judged by the procedure. It must carry INTERRUPTED_UPLOAD, not
+    // SQL_EXCEPTION, regardless of how the failure text happens to read.
+    const errorCodes = await fetchIngestionErrorCodes();
+    console.log(`[abort-mid] ingestion error codes=${JSON.stringify(errorCodes)}`);
+    expect(errorCodes).toEqual(['INTERRUPTED_UPLOAD']);
   }, 60000);
 
   // -------------------------------------------------------------------------
@@ -639,6 +660,79 @@ describe('ingestBatch — integration', () => {
       );
       console.log(`[kill-interrupt] unresolved coremeasurements rows=${unresolvedRows[0].count}`);
       expect(Number(unresolvedRows[0].count)).toBe(EXPECTED_ROW_COUNT);
+
+      // A KILLed procedure call is a system failure, not a per-row data
+      // defect — it must carry SQL_EXCEPTION.
+      const errorCodes = await fetchIngestionErrorCodes();
+      console.log(`[kill-interrupt] ingestion error codes=${JSON.stringify(errorCodes)}`);
+      expect(errorCodes).toEqual(['SQL_EXCEPTION']);
+    } finally {
+      executeQuerySpy.mockRestore();
+    }
+  }, 60000);
+
+  // -------------------------------------------------------------------------
+  // 7b. Ordinary unrecoverable error (outer-catch "else" branch): the sub-batch
+  // is abandoned after a single KILLed attempt (fast path to the giving-up
+  // code), and the FIRST attempt to move its rows to unresolved coremeasurements
+  // itself throws with a message that contains NO SQL keyword — proving the
+  // code is still SQL_EXCEPTION because the caller declared that kind
+  // explicitly, not because prose inference happened to match. ingestBatch's
+  // outer catch then retries the move (this time for real) and completes
+  // normally.
+  // -------------------------------------------------------------------------
+
+  it('classifies the outer-catch unrecoverable-error branch as SQL_EXCEPTION even when the thrown message has no SQL keyword', async () => {
+    await stageFixtureRows();
+    expect(await countTemporaryRows()).toBe(EXPECTED_ROW_COUNT);
+
+    const interruptError = Object.assign(new Error(MYSQL_QUERY_INTERRUPTED_MESSAGE), {
+      code: MYSQL_CODE_QUERY_INTERRUPTED,
+      errno: MYSQL_ERRNO_QUERY_INTERRUPTED,
+      sqlState: MYSQL_SQLSTATE_QUERY_INTERRUPTED
+    });
+    const NO_SQL_KEYWORD_MESSAGE = 'Unexpected condition while finalizing sub-batch cleanup';
+    let coreMeasurementsInsertAttempts = 0;
+    const realExecuteQuery = connectionManager.executeQuery.bind(connectionManager);
+    const executeQuerySpy = vi
+      .spyOn(connectionManager, 'executeQuery')
+      .mockImplementation(async (query: string, params?: unknown[], transactionId?: string) => {
+        if (query.includes('bulkingestionprocess')) {
+          throw interruptError;
+        }
+        // Unique to moveTemporaryBatchToFailedMeasurements's INSERT ... SELECT
+        // (RawTreeTag <- tm.TreeTag) — reject only its FIRST occurrence so the
+        // giving-up code inside processSubBatch fails and propagates to
+        // ingestBatch's outer catch, which then retries for real.
+        if (query.includes('INSERT INTO') && query.includes('coremeasurements') && query.includes('tm.TreeTag')) {
+          coreMeasurementsInsertAttempts++;
+          if (coreMeasurementsInsertAttempts === 1) {
+            throw new Error(NO_SQL_KEYWORD_MESSAGE);
+          }
+        }
+        return realExecuteQuery(query, params, transactionId);
+      });
+
+    try {
+      const result = await runIngestBatch();
+
+      console.log(`[unrecoverable] coreMeasurementsInsertAttempts=${coreMeasurementsInsertAttempts}`);
+      expect(coreMeasurementsInsertAttempts, 'the injected failure must have been hit once before the real retry').toBeGreaterThanOrEqual(2);
+
+      expect(result.subBatchResults).toHaveLength(1);
+      expect(result.subBatchResults[0].batchFailedButHandled).toBe(true);
+      expect(result.subBatchResults[0].rowCount).toBe(EXPECTED_ROW_COUNT);
+
+      expect(await countTemporaryRows()).toBe(0);
+      const [unresolvedRows] = await connection.query<RowDataPacket[]>(
+        'SELECT COUNT(*) AS count FROM coremeasurements WHERE UploadFileID = ? AND StemGUID IS NULL',
+        [FILE_NAME]
+      );
+      expect(Number(unresolvedRows[0].count)).toBe(EXPECTED_ROW_COUNT);
+
+      const errorCodes = await fetchIngestionErrorCodes();
+      console.log(`[unrecoverable] ingestion error codes=${JSON.stringify(errorCodes)}`);
+      expect(errorCodes).toEqual(['SQL_EXCEPTION']);
     } finally {
       executeQuerySpy.mockRestore();
     }

--- a/frontend/tests/integration/record-invalid-rows.test.ts
+++ b/frontend/tests/integration/record-invalid-rows.test.ts
@@ -92,7 +92,9 @@ vi.mock('@/ailogger', () => ({
 }));
 
 import ConnectionManager from '@/lib/db/connectionmanager';
-import { recordInvalidRows, deleteUnresolvedRowsForBatchFamily, type InvalidRowContext } from '@/lib/uploads/record-invalid-rows';
+import { recordInvalidRows, recordFailedMeasurementRows, deleteUnresolvedRowsForBatchFamily, type InvalidRowContext } from '@/lib/uploads/record-invalid-rows';
+import { insertIngestionFailureRows, FALLBACK_FAILURE_REASON } from '@/config/measurementerrors';
+import type { FailedMeasurementsRDS } from '@/lib/db/definitions/core';
 
 // ---------------------------------------------------------------------------
 // Fixture constants
@@ -199,7 +201,10 @@ describe('recordInvalidRows / deleteUnresolvedRowsForBatchFamily — integration
   // -------------------------------------------------------------------------
 
   it('records 2 parse-reject rows: full row + sparse row (tag+failureReason only)', async () => {
-    const ctx: InvalidRowContext = { schema, plotID, censusID, fileName: FILE_NAME, batchID: BATCH_ID };
+    // sourceRowIndexOffset: -3 pushes these two worker rejects into the real
+    // negative SourceRowIndex namespace (-2, -1) that the async worker uses to
+    // stay out of bulkingestionprocess's positive auto-increment range.
+    const ctx: InvalidRowContext = { schema, plotID, censusID, fileName: FILE_NAME, batchID: BATCH_ID, sourceRowIndexOffset: -3 };
 
     const fullRow = {
       tag: 'T0100',
@@ -216,9 +221,12 @@ describe('recordInvalidRows / deleteUnresolvedRowsForBatchFamily — integration
       failureReason: 'Missing required fields: quadrat'
     };
 
+    // failureReason: null (not the fallback literal) proves the CHOKE-POINT
+    // fallback in insertIngestionFailureRows applies FALLBACK_FAILURE_REASON,
+    // rather than the fixture merely passing a literal string through.
     const sparseRow = {
       tag: 'T0101',
-      failureReason: 'Unknown parse error'
+      failureReason: null
     };
 
     const transactionID = await connectionManager.beginTransaction();
@@ -260,8 +268,12 @@ describe('recordInvalidRows / deleteUnresolvedRowsForBatchFamily — integration
     expect(parseFloat(fullRecorded.RawYText)).toBeCloseTo(2.75);
     expect(parseFloat(fullRecorded.MeasuredDBHText)).toBeCloseTo(12.345);
     expect(parseFloat(fullRecorded.MeasuredHOMText)).toBeCloseTo(1.3);
-    // Description stores the comments field; failure reason goes into measurement_error_log.
-    expect(fullRecorded.Description).toBe('test comment');
+    // Description round-trips the verbatim failure reason; RawComments round-trips
+    // the verbatim comments. They are NOT copies of each other — this is the
+    // #454 fix under test (Description used to be silently NULL, or overwritten
+    // with the comments field, depending on the code path).
+    expect(fullRecorded.Description).toBe('Missing required fields: quadrat');
+    expect(fullRecorded.RawComments).toBe('test comment');
 
     // Verify the failure reason was written to measurement_error_log.
     const fullMeasurementID = await fetchCoreMeasurementID(FILE_NAME, BATCH_ID, 'T0100');
@@ -275,17 +287,121 @@ describe('recordInvalidRows / deleteUnresolvedRowsForBatchFamily — integration
     console.log(`[test1] sparse row: tag=${sparseRecorded.RawTreeTag} description=${sparseRecorded.Description} stemTag=${sparseRecorded.RawStemTag}`);
     expect(sparseRecorded.RawTreeTag).toBe('T0101');
     expect(sparseRecorded.RawStemTag).toBeNull();
-    // Sparse row has no comments — Description is null; failure reason is in measurement_error_log.
-    expect(sparseRecorded.Description).toBeNull();
+    // Sparse row's failureReason is null — the choke point (normalizeFailureDescription
+    // in config/measurementerrors.ts) must apply FALLBACK_FAILURE_REASON, never leave
+    // Description NULL. A NULL Description here is exactly what the #454 detector query
+    // (SourceRowIndex < 0 AND Description IS NULL) flags as an unrecorded reject.
+    expect(sparseRecorded.Description).toBe(FALLBACK_FAILURE_REASON);
     const sparseMeasurementID = await fetchCoreMeasurementID(FILE_NAME, BATCH_ID, 'T0101');
     expect(sparseMeasurementID).not.toBeNull();
     const sparseErrors = await fetchMeasurementErrors(sparseMeasurementID!);
     console.log(`[test1] sparse row error_log entries: ${JSON.stringify(sparseErrors)}`);
     expect(sparseErrors.length).toBeGreaterThan(0);
+    // An unrecognized (here: absent) reason must classify as UNCLASSIFIED_REJECT,
+    // never SQL_EXCEPTION — the choke point must not guess a system-failure code
+    // from prose it doesn't recognize.
+    const sparseErrorCodes = sparseErrors.map(row => row.ErrorCode);
+    console.log(`[test1] sparse row error codes: ${JSON.stringify(sparseErrorCodes)}`);
+    expect(sparseErrorCodes).toContain('UNCLASSIFIED_REJECT');
+    expect(sparseErrorCodes).not.toContain('SQL_EXCEPTION');
+
+    // #454 detector, scoped to this fixture's UploadFileID: fresh worker-path
+    // writes must never leave a negative-SourceRowIndex row with a NULL
+    // Description. Never run this unscoped — other tests' seed data is out of
+    // bounds for this assertion.
+    const [detectorRows] = await connection.query<RowDataPacket[]>(
+      `SELECT COUNT(*) AS n FROM \`${schema}\`.coremeasurements
+       WHERE UploadFileID = ? AND SourceRowIndex < 0 AND Description IS NULL`,
+      [FILE_NAME]
+    );
+    console.log(`[test1] #454 detector (scoped to fixture file) n=${detectorRows[0].n}`);
+    expect(Number(detectorRows[0].n)).toBe(0);
   });
 
   // -------------------------------------------------------------------------
-  // Test 2: deleteUnresolvedRowsForBatchFamily scoped delete behavior.
+  // Test 2: sequential-path insert — proves insertPreparedIngestionFailureRowsSequential
+  // against real SQL. The bulk-metadata cases above (batchID set) never reach this
+  // code path; only a falsy batchID does.
+  // -------------------------------------------------------------------------
+
+  it('insertIngestionFailureRows with batchID: null takes the sequential insert path and round-trips Description/RawComments', async () => {
+    const reason = 'Unparseable date value: 31/13/2020';
+    const comments = 'sequential path note';
+
+    const transactionID = await connectionManager.beginTransaction();
+    const insertedIDs = await insertIngestionFailureRows(
+      connectionManager,
+      schema,
+      [
+        {
+          plotID,
+          censusID,
+          tag: 'T0400',
+          comments,
+          failureReason: reason,
+          fileID: FILE_NAME,
+          batchID: null,
+          sourceRowIndex: 1
+        }
+      ],
+      transactionID
+    );
+    await connectionManager.commitTransaction(transactionID);
+
+    console.log(`[test2] insertIngestionFailureRows (sequential path) returned insertedIDs=${JSON.stringify(insertedIDs)}`);
+    expect(insertedIDs).toHaveLength(1);
+
+    const [rows] = await connection.query<RowDataPacket[]>(
+      `SELECT Description, RawComments, UploadBatchID, StemGUID
+       FROM \`${schema}\`.coremeasurements
+       WHERE CoreMeasurementID = ?`,
+      [insertedIDs[0]]
+    );
+    console.log(`[test2] sequential-path row: ${JSON.stringify(rows[0])}`);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].UploadBatchID).toBeNull();
+    expect(rows[0].StemGUID).toBeNull();
+    expect(rows[0].Description).toBe(reason);
+    expect(rows[0].RawComments).toBe(comments);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3: HTTP-shape (recordFailedMeasurementRows) — proves the batchedupload
+  // route's persistence boundary round-trips the actual wire shape, including
+  // the plural `failureReasons` field name.
+  // -------------------------------------------------------------------------
+
+  it('recordFailedMeasurementRows persists the HTTP wire shape { comments, failureReasons } verbatim', async () => {
+    const reason = 'Missing required fields: date';
+    const comments = 'route note';
+    const httpBatchID = `${BATCH_ID}__http`;
+
+    const transactionID = await connectionManager.beginTransaction();
+    const count = await recordFailedMeasurementRows(
+      connectionManager,
+      schema,
+      [{ tag: 'T0500', comments, failureReasons: reason } as FailedMeasurementsRDS],
+      FILE_NAME,
+      httpBatchID,
+      plotID,
+      censusID,
+      transactionID
+    );
+    await connectionManager.commitTransaction(transactionID);
+
+    console.log(`[test3] recordFailedMeasurementRows returned count=${count}`);
+    expect(count).toBe(1);
+
+    const recorded = await fetchRecordedRows(httpBatchID);
+    console.log(`[test3] HTTP-shape row: ${JSON.stringify(recorded)}`);
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].RawTreeTag).toBe('T0500');
+    expect(recorded[0].Description).toBe(reason);
+    expect(recorded[0].RawComments).toBe(comments);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 4: deleteUnresolvedRowsForBatchFamily scoped delete behavior.
   // -------------------------------------------------------------------------
 
   it('deleteUnresolvedRowsForBatchFamily: returns count, clears unresolved rows, does not delete resolved or different-batch rows', async () => {
@@ -303,7 +419,7 @@ describe('recordInvalidRows / deleteUnresolvedRowsForBatchFamily — integration
     );
     await connectionManager.commitTransaction(txInsert);
 
-    console.log('[test2] seeded 2 unresolved rows under BATCH_ID');
+    console.log('[test4] seeded 2 unresolved rows under BATCH_ID');
 
     // Also insert a "resolved" control row under BATCH_ID with non-NULL StemGUID.
     // We need a real StemGUID — insert a stem that satisfies the FK, then insert
@@ -317,7 +433,7 @@ describe('recordInvalidRows / deleteUnresolvedRowsForBatchFamily — integration
       [censusID]
     );
     const treeID: number = treeInsertResult.insertId;
-    console.log(`[test2] inserted control tree treeID=${treeID}`);
+    console.log(`[test4] inserted control tree treeID=${treeID}`);
 
     const [stemInsertResult]: any = await connection.query(
       `INSERT INTO \`${schema}\`.stems (TreeID, StemTag, LocalX, LocalY, CensusID, IsActive)
@@ -325,7 +441,7 @@ describe('recordInvalidRows / deleteUnresolvedRowsForBatchFamily — integration
       [treeID, censusID]
     );
     const stemGUID: number = stemInsertResult.insertId;
-    console.log(`[test2] inserted control stem stemGUID=${stemGUID}`);
+    console.log(`[test4] inserted control stem stemGUID=${stemGUID}`);
 
     // Insert a resolved coremeasurement (StemGUID IS NOT NULL) under the same
     // BATCH_ID — this row must survive the delete.
@@ -335,13 +451,13 @@ describe('recordInvalidRows / deleteUnresolvedRowsForBatchFamily — integration
        VALUES (?, ?, '2024-01-01', 5.0, 1.3, ?, ?, 1)`,
       [censusID, stemGUID, FILE_NAME, BATCH_ID]
     );
-    console.log('[test2] inserted 1 resolved control row (StemGUID IS NOT NULL)');
+    console.log('[test4] inserted 1 resolved control row (StemGUID IS NOT NULL)');
 
     // Also record 1 unresolved row under a DIFFERENT batch — must survive the delete.
     const txOther = await connectionManager.beginTransaction();
     await recordInvalidRows(connectionManager, { ...ctx, batchID: OTHER_BATCH_ID }, [{ tag: 'T0299', failureReason: 'Other batch reject' }], txOther);
     await connectionManager.commitTransaction(txOther);
-    console.log('[test2] seeded 1 unresolved row under OTHER_BATCH_ID');
+    console.log('[test4] seeded 1 unresolved row under OTHER_BATCH_ID');
 
     // And 1 unresolved row under a SUB-BATCH of BATCH_ID — this one MUST be
     // deleted. An interrupted split leaves rows under `__subNNN`; a delete that
@@ -351,24 +467,24 @@ describe('recordInvalidRows / deleteUnresolvedRowsForBatchFamily — integration
     const txSub = await connectionManager.beginTransaction();
     await recordInvalidRows(connectionManager, { ...ctx, batchID: SUB_BATCH_ID }, [{ tag: 'T0298', failureReason: 'Sub-batch reject' }], txSub);
     await connectionManager.commitTransaction(txSub);
-    console.log(`[test2] seeded 1 unresolved row under ${SUB_BATCH_ID}`);
+    console.log(`[test4] seeded 1 unresolved row under ${SUB_BATCH_ID}`);
 
     // Run the delete.
     const txDelete = await connectionManager.beginTransaction();
     const deletedCount = await deleteUnresolvedRowsForBatchFamily(connectionManager, schema, FILE_NAME, BATCH_ID, censusID, txDelete);
     await connectionManager.commitTransaction(txDelete);
 
-    console.log(`[test2] deleteUnresolvedRowsForBatchFamily returned deletedCount=${deletedCount}`);
+    console.log(`[test4] deleteUnresolvedRowsForBatchFamily returned deletedCount=${deletedCount}`);
     // 2 under the original ID + 1 under its sub-batch.
     expect(deletedCount).toBe(3);
 
     const remainingSubBatch = await fetchRecordedRows(SUB_BATCH_ID);
-    console.log(`[test2] remaining rows under ${SUB_BATCH_ID} after delete: ${remainingSubBatch.length}`);
+    console.log(`[test4] remaining rows under ${SUB_BATCH_ID} after delete: ${remainingSubBatch.length}`);
     expect(remainingSubBatch).toHaveLength(0);
 
     // Verify the unresolved BATCH_ID rows are gone.
     const remainingBatch = await fetchRecordedRows(BATCH_ID);
-    console.log(`[test2] remaining rows under BATCH_ID after delete: ${remainingBatch.length}`);
+    console.log(`[test4] remaining rows under BATCH_ID after delete: ${remainingBatch.length}`);
     expect(remainingBatch).toHaveLength(0);
 
     // Verify the resolved row (StemGUID IS NOT NULL) under BATCH_ID survived.
@@ -377,18 +493,18 @@ describe('recordInvalidRows / deleteUnresolvedRowsForBatchFamily — integration
        WHERE UploadFileID = ? AND UploadBatchID = ? AND StemGUID IS NOT NULL`,
       [FILE_NAME, BATCH_ID]
     );
-    console.log(`[test2] resolved rows under BATCH_ID after delete: ${resolvedRows.length}`);
+    console.log(`[test4] resolved rows under BATCH_ID after delete: ${resolvedRows.length}`);
     expect(resolvedRows).toHaveLength(1);
 
     // Verify the OTHER_BATCH_ID row survived.
     const remainingOther = await fetchRecordedRows(OTHER_BATCH_ID);
-    console.log(`[test2] remaining rows under OTHER_BATCH_ID after delete: ${remainingOther.length}`);
+    console.log(`[test4] remaining rows under OTHER_BATCH_ID after delete: ${remainingOther.length}`);
     expect(remainingOther).toHaveLength(1);
     expect(remainingOther[0].RawTreeTag).toBe('T0299');
   });
 
   // -------------------------------------------------------------------------
-  // Test 3: Retry simulation — re-record after delete produces clean state.
+  // Test 5: Retry simulation — re-record after delete produces clean state.
   // -------------------------------------------------------------------------
 
   it('retry simulation: record → delete → re-record yields exactly the new rows', async () => {
@@ -406,37 +522,38 @@ describe('recordInvalidRows / deleteUnresolvedRowsForBatchFamily — integration
       txFirst
     );
     await connectionManager.commitTransaction(txFirst);
-    console.log(`[test3] first attempt recorded count=${firstCount}`);
+    console.log(`[test5] first attempt recorded count=${firstCount}`);
     expect(firstCount).toBe(2);
 
     const afterFirst = await fetchRecordedRows(BATCH_ID);
-    console.log(`[test3] rows after first attempt: ${afterFirst.length}`);
+    console.log(`[test5] rows after first attempt: ${afterFirst.length}`);
     expect(afterFirst).toHaveLength(2);
 
     // Retry cleanup: delete the first-attempt rows.
     const txCleanup = await connectionManager.beginTransaction();
     const cleanedCount = await deleteUnresolvedRowsForBatchFamily(connectionManager, schema, FILE_NAME, BATCH_ID, censusID, txCleanup);
     await connectionManager.commitTransaction(txCleanup);
-    console.log(`[test3] cleanup deleted count=${cleanedCount}`);
+    console.log(`[test5] cleanup deleted count=${cleanedCount}`);
     expect(cleanedCount).toBe(2);
 
     const afterCleanup = await fetchRecordedRows(BATCH_ID);
-    console.log(`[test3] rows after cleanup: ${afterCleanup.length}`);
+    console.log(`[test5] rows after cleanup: ${afterCleanup.length}`);
     expect(afterCleanup).toHaveLength(0);
 
     // Second attempt (retry): record 1 row (simulating fewer failures on retry).
     const txRetry = await connectionManager.beginTransaction();
     const retryCount = await recordInvalidRows(connectionManager, ctx, [{ tag: 'T0302', failureReason: 'Retry attempt error C' }], txRetry);
     await connectionManager.commitTransaction(txRetry);
-    console.log(`[test3] retry recorded count=${retryCount}`);
+    console.log(`[test5] retry recorded count=${retryCount}`);
     expect(retryCount).toBe(1);
 
     const afterRetry = await fetchRecordedRows(BATCH_ID);
-    console.log(`[test3] rows after retry: ${afterRetry.length} — ${JSON.stringify(afterRetry)}`);
+    console.log(`[test5] rows after retry: ${afterRetry.length} — ${JSON.stringify(afterRetry)}`);
     expect(afterRetry).toHaveLength(1);
     expect(afterRetry[0].RawTreeTag).toBe('T0302');
-    // No comments on this row — Description is null; failure reason is in measurement_error_log.
-    expect(afterRetry[0].Description).toBeNull();
+    // Description round-trips the verbatim failure reason (no comments on this row).
+    expect(afterRetry[0].Description).toBe('Retry attempt error C');
+    expect(afterRetry[0].RawComments).toBeNull();
     expect(afterRetry[0].StemGUID).toBeNull();
     expect(afterRetry[0].UploadBatchID).toBe(BATCH_ID);
     expect(afterRetry[0].CensusID).toBe(censusID);
@@ -444,7 +561,7 @@ describe('recordInvalidRows / deleteUnresolvedRowsForBatchFamily — integration
     const retryMeasurementID = await fetchCoreMeasurementID(FILE_NAME, BATCH_ID, 'T0302');
     expect(retryMeasurementID).not.toBeNull();
     const retryErrors = await fetchMeasurementErrors(retryMeasurementID!);
-    console.log(`[test3] retry row error_log entries: ${JSON.stringify(retryErrors)}`);
+    console.log(`[test5] retry row error_log entries: ${JSON.stringify(retryErrors)}`);
     expect(retryErrors.length).toBeGreaterThan(0);
   });
 });

--- a/frontend/tests/integration/setupbulkfailure-authz.integration.test.ts
+++ b/frontend/tests/integration/setupbulkfailure-authz.integration.test.ts
@@ -128,6 +128,16 @@ describe('GET /api/setupbulkfailure/[fileID]/[batchID] authz', () => {
     expect(res.status).toBe(HTTP_OK);
     // Retained token check ran, and the failure transfer executed for a member.
     expect(requireUploadSessionOwnershipMock).toHaveBeenCalledTimes(1);
-    expect(transferSpies.moveTemporaryBatchToFailedMeasurements).toHaveBeenCalledTimes(1);
+    // The route always declares this call site's kind explicitly — a required
+    // param proves *a* kind was passed, but the exact-args check below proves
+    // it's the *correct* one ('sql_exception' for this system-failure path).
+    expect(transferSpies.moveTemporaryBatchToFailedMeasurements).toHaveBeenCalledWith(
+      expect.anything(),
+      MEMBER_SCHEMA,
+      TEST_FILE_ID,
+      TEST_BATCH_ID,
+      'Batch moved after max attempts',
+      'sql_exception'
+    );
   });
 });

--- a/frontend/tests/integration/setupbulkfailure-authz.integration.test.ts
+++ b/frontend/tests/integration/setupbulkfailure-authz.integration.test.ts
@@ -82,8 +82,9 @@ vi.mock('@/lib/db/connectionmanager', () => ({
   }
 }));
 
-function buildRequest(schema: string): NextRequest {
-  return new NextRequest(`http://localhost/api/setupbulkfailure/${TEST_FILE_ID}/${TEST_BATCH_ID}?schema=${schema}`, {
+function buildRequest(schema: string, reason?: string): NextRequest {
+  const reasonParam = reason === undefined ? '' : `&reason=${encodeURIComponent(reason)}`;
+  return new NextRequest(`http://localhost/api/setupbulkfailure/${TEST_FILE_ID}/${TEST_BATCH_ID}?schema=${schema}${reasonParam}`, {
     method: 'GET',
     headers: { 'x-upload-session-id': TEST_SESSION_ID }
   });
@@ -138,6 +139,88 @@ describe('GET /api/setupbulkfailure/[fileID]/[batchID] authz', () => {
       TEST_BATCH_ID,
       'Batch moved after max attempts',
       'sql_exception'
+    );
+  });
+});
+
+/**
+ * This route is the one failure-transfer boundary whose kind is not known by
+ * its caller: the browser sends whatever killed its setupbulkprocedure request
+ * as free text. Hardcoding 'sql_exception' here is what recorded 106,227 clean
+ * Harvard Forest rows as if each carried an ingestion SQL error after an Azure
+ * front-end timeout.
+ */
+describe('GET /api/setupbulkfailure/[fileID]/[batchID] failure-kind classification', () => {
+  const INTERRUPTION_REASON = 'Server error 504: 504.0 GatewayTimeout';
+  const GENUINE_SQL_REASON = 'Server error 500: Duplicate entry for key uq_coremeasurements';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireUploadSessionOwnershipMock.mockResolvedValue(undefined);
+    dbSpies.executeQuery.mockResolvedValue([{ PlotID: 22, CensusID: 6 }]);
+    transferSpies.moveTemporaryBatchToFailedMeasurements.mockResolvedValue(3);
+  });
+
+  it('records a front-end timeout as interrupted_upload, not as a per-row ingestion error', async () => {
+    const { auth } = await import('@/auth');
+    vi.mocked(auth).mockResolvedValueOnce({
+      user: { email: MEMBER_EMAIL, userStatus: 'field crew', sites: [{ schemaName: MEMBER_SCHEMA }] }
+    } as any);
+
+    const { GET } = await import('@/app/api/setupbulkfailure/[fileID]/[batchID]/route');
+    const res = await GET(buildRequest(MEMBER_SCHEMA, INTERRUPTION_REASON), makeContext());
+
+    expect(res.status).toBe(HTTP_OK);
+    expect(transferSpies.moveTemporaryBatchToFailedMeasurements).toHaveBeenCalledWith(
+      expect.anything(),
+      MEMBER_SCHEMA,
+      TEST_FILE_ID,
+      TEST_BATCH_ID,
+      INTERRUPTION_REASON,
+      'interrupted_upload'
+    );
+  });
+
+  it('keeps a genuine server-side failure as sql_exception', async () => {
+    const { auth } = await import('@/auth');
+    vi.mocked(auth).mockResolvedValueOnce({
+      user: { email: MEMBER_EMAIL, userStatus: 'field crew', sites: [{ schemaName: MEMBER_SCHEMA }] }
+    } as any);
+
+    const { GET } = await import('@/app/api/setupbulkfailure/[fileID]/[batchID]/route');
+    const res = await GET(buildRequest(MEMBER_SCHEMA, GENUINE_SQL_REASON), makeContext());
+
+    expect(res.status).toBe(HTTP_OK);
+    expect(transferSpies.moveTemporaryBatchToFailedMeasurements).toHaveBeenCalledWith(
+      expect.anything(),
+      MEMBER_SCHEMA,
+      TEST_FILE_ID,
+      TEST_BATCH_ID,
+      GENUINE_SQL_REASON,
+      'sql_exception'
+    );
+  });
+
+  it('carries the same kind into the sub-batch fallback transfer', async () => {
+    const { auth } = await import('@/auth');
+    vi.mocked(auth).mockResolvedValueOnce({
+      user: { email: MEMBER_EMAIL, userStatus: 'field crew', sites: [{ schemaName: MEMBER_SCHEMA }] }
+    } as any);
+    // No exact-match rows: the route falls back to moving every sub-batch.
+    transferSpies.moveTemporaryBatchToFailedMeasurements.mockResolvedValueOnce(0);
+    transferSpies.moveTemporarySubBatchesToFailedMeasurements.mockResolvedValueOnce(5);
+
+    const { GET } = await import('@/app/api/setupbulkfailure/[fileID]/[batchID]/route');
+    const res = await GET(buildRequest(MEMBER_SCHEMA, INTERRUPTION_REASON), makeContext());
+
+    expect(res.status).toBe(HTTP_OK);
+    expect(transferSpies.moveTemporarySubBatchesToFailedMeasurements).toHaveBeenCalledWith(
+      expect.anything(),
+      MEMBER_SCHEMA,
+      TEST_FILE_ID,
+      TEST_BATCH_ID,
+      INTERRUPTION_REASON,
+      'interrupted_upload'
     );
   });
 });


### PR DESCRIPTION
## What this fixes

A rejected upload row currently cannot tell a researcher what went wrong.

`insertPreparedIngestionFailureRows` binds `row.comments` into
`coremeasurements.Description`, so the parser's reject reason is never persisted
anywhere — the column holds the researcher's own comment, usually blank. The
reason string survives only long enough to pick an error code, and the
classifier's fallback is:

```
ailogger.warn(`...unmapped error pattern defaulting to SQL_EXCEPTION: "${reason}"`);
codes.push('SQL_EXCEPTION');
```

The parser's two most common messages — `Non-numeric value for dbh: N/A` and
`Unparseable date value: …` — match no branch. So a typo in one cell surfaces in
the errors explorer as **"Ingestion SQL exception"**: a database fault, for what
is actually a fixable value.

## What changes

- `Description` holds the normalized reject reason; `RawComments` keeps the
  researcher's comment. The two stop being the same string.
- Unrecognized reasons classify as `UNCLASSIFIED_REJECT`, which says the reason
  was not recognized, rather than asserting a SQL exception that did not happen.
- The remaining parser shapes classify to specific codes, each mapped to the
  column at fault: non-numeric DBH/HOM/coordinates, unparseable dates,
  mis-parsed tag rows, per-field missing-value lists, decimal overflow.
- System-failure transfers carry an explicit failure kind instead of inferring
  one from prose. `setupbulkfailure` is the one boundary whose kind its caller
  cannot state — the browser sends whatever killed its request as free text — so
  it recovers the kind there, keeping front-end 504s classified as
  `INTERRUPTED_UPLOAD` rather than as per-row data errors.
- Editing a failed row no longer overwrites the recorded reason with the
  comment text.

Also carries the plot-coordinate correction path from `feat/plot-coordinate-ingest`
(`355cc300`, `9bbbc7c3`), which was never merged: #456 landed px/py *ingest*
(`RawPlotX`/`RawPlotY`), but the correction path — editable `px`/`py` grid cells
and `px`/`py` columns in revision uploads — is still absent from dev.

## Behavior differences worth knowing

- Stricter edit boundary: non-base-10 (`0x10`, `100abc`) and values outside
  `DECIMAL(12,6)` are refused with 422 instead of being coerced.
- `INSERT IGNORE` → `INSERT` on `temporarymeasurements`, plus row-count and SQL
  warning checks. Staging problems that were silently dropped now fail the apply.
- `batchedupload` requires positive-integer `plotID`/`censusID` (`parseInt`
  previously accepted `12abc`) and ignores client-supplied `fileID`/`batchID`.
- A single malformed cell demotes its own row to `invalidRows` with its
  `csvIndex`, instead of 422-ing the whole file with a bare field name.
- `null` plot coordinates render blank in the grid rather than as `0.00`.

## Not included

**No backfill.** Rows already rejected in production keep `SQL_EXCEPTION`, keep
`MISSING_FIELD_COORDINATES`, and keep a `Description` holding a comment or
nothing. Only rows rejected after deploy get legible reasons, so the errors
explorer will show a mix of old opaque rows and new legible ones. Backfilling
the existing parked rows is a separate migration.

The five new error codes are not in the `tablestructures.sql` seed. They are
created on demand per schema by `ensureMeasurementErrorDefinition`, as
`INTERRUPTED_UPLOAD` already is, so no migration is required — a freshly
provisioned schema simply does not list them until its first matching reject.
