### PR TITLE
fix(migrations): restore the tampered seed-validation-19 migration

### DIFF
--- a/frontend/db/migrations/schema-contract-repair/2026-08-27-02-seed-validation-19.sql
+++ b/frontend/db/migrations/schema-contract-repair/2026-08-27-02-seed-validation-19.sql
@@ -20,9 +20,9 @@ BEGIN
 END;
 
 SET @id_conflict := (SELECT COUNT(*) FROM sitespecificvalidations
-                     WHERE ValidationID = 19 AND NOT (ProcedureName <=> 'ValidatePlotCoordinateConsistency'));
+                     WHERE ValidationID = 19 AND ProcedureName <> 'ValidatePlotCoordinateConsistency');
 SET @name_conflict := (SELECT COUNT(*) FROM sitespecificvalidations
-                       WHERE ProcedureName = 'ValidatePlotCoordinateConsistency' AND NOT (ValidationID <=> 19));
+                       WHERE ProcedureName = 'ValidatePlotCoordinateConsistency' AND ValidationID <> 19);
 SET @enabled_without_helper := (
   SELECT COUNT(*) FROM sitespecificvalidations
    WHERE ValidationID = 19


### PR DESCRIPTION
Every deploy since 2026-09-02 has failed at `migrate-and-verify`, on both dev and the production promotion:

```
SCHEMA FAILED  forestgeo_cooksbranch: Migration "2026-08-27-02-seed-validation-19" is recorded
applied with checksum 558d61d5... but the current file hashes to 071ca019...
A migration already applied to a live schema must never be edited; create a new migration instead.
```

Commit `66744586` (PR #463, reject-reason persistence) edited that migration file after it had already been applied, switching two preflight comparisons to the NULL-safe `<=>` form.

## Why a plain restore is the right fix

The edit was a no-op. `sitespecificvalidations.ProcedureName` is `not null` and `ValidationID` is the auto-increment primary key, both in `tablestructures.sql` and in all 12 live schemas, so `NOT (col <=> 'x')` is equivalent to `col <> 'x'`. Queried across every schema, no row is classified differently by the two forms.

So no new migration is needed to carry the change forward: restoring the original text changes no behaviour, the file hashes back to `558d61d5`, and the ledger matches again.

## Ledger state before the fix

All 12 schemas recorded the migration `applied` with the **old** checksum on 2026-08-28 05:27–05:29 UTC; **none** recorded the new one, because the runner aborts on the first schema. The restore is therefore uniform — no schema is left inconsistent, and the migration will not re-run anywhere.

## Verification

`npm run test:integration -- schema-migration-contract` against local MySQL: 12/12 passed, including the preflight cases that exercise the reverted comparisons directly — refusing to seed when ID 19 is held by a custom rule, and when the procedure name exists under a different ID.

## Follow-ups worth filing separately

- Nothing in the PR gate catches editing an already-applied migration; it only surfaces at deploy time, two days later.
- `production` and `development_temp` resolve to the same MySQL server and the same 12 schemas, so a dev deploy migrates production's schemas.