### PR TITLE
Quarantine a schema that fails the deploy contract gate (#429) + azureroot definer close-out (#399)

### DIFF
--- a/.github/workflows/dev-forestgeo-livesite.yml
+++ b/.github/workflows/dev-forestgeo-livesite.yml
@@ -228,9 +228,14 @@ jobs:
           npx tsx scripts/apply-catalog-migrations.ts --azure --apply
         continue-on-error: false
 
+      # A schema that has NEVER passed this gate and fails it is quarantined (the
+      # app refuses it with 503 SCHEMA_QUARANTINED) and the deploy continues; a
+      # schema that passed before and now fails still blocks the deploy. The
+      # result file feeds the "Report quarantined schemas" step below. See #429.
       - name: Apply schema migrations to all schemas
         env:
           AZURE_SQL_PASSWORD: ${{ secrets.AZURE_SQL_PASSWORD }}
+          SCHEMA_GATE_RESULT_PATH: ${{ runner.temp }}/schema-gate-result.json
         run: |
           cd frontend/
           npx tsx scripts/apply-schema-migrations.ts --all-sites --apply
@@ -243,6 +248,57 @@ jobs:
           cd frontend/
           npx tsx scripts/check-schema-contract.ts --all-sites
         continue-on-error: false
+
+      # Quarantine is not a failure, so nothing else would tell a human. Opens one
+      # issue per distinct set of quarantined schemas and comments on it while it
+      # stays open. Never blocks the deploy it reports on.
+      - name: Report quarantined schemas
+        if: always()
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          SCHEMA_GATE_RESULT_PATH: ${{ runner.temp }}/schema-gate-result.json
+        with:
+          script: |
+            const fs = require('fs');
+            const LABEL = 'schema-quarantine';
+            const resultPath = process.env.SCHEMA_GATE_RESULT_PATH;
+            if (!fs.existsSync(resultPath)) {
+              core.info('No schema gate result file; the apply step did not complete.');
+              return;
+            }
+            const result = JSON.parse(fs.readFileSync(resultPath, 'utf8'));
+            if (!Array.isArray(result.quarantined) || result.quarantined.length === 0) {
+              core.info('No schemas quarantined.');
+              return;
+            }
+            const names = result.quarantined.map(entry => entry.schema).sort();
+            const title = `Schema quarantined: ${names.join(', ')}`;
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const rows = result.quarantined.map(entry => `| \`${entry.schema}\` | ${entry.since} | ${entry.reason.split('\n')[0]} |`).join('\n');
+            const body = [
+              `## Schema contract gate quarantine`,
+              ``,
+              `**Run:** ${runUrl}`,
+              `**Branch:** ${context.ref}`,
+              ``,
+              `| Schema | Quarantined since | Reason (first line) |`,
+              `|---|---|---|`,
+              rows,
+              ``,
+              `The deploy continued for every other schema. Site-scoped API requests for these schemas return 503 \`SCHEMA_QUARANTINED\` until a later deploy passes the gate for them.`,
+              ``,
+              `Repair: see "Quarantined schemas" in \`frontend/docs/deployment-to-development.md\`. Never edit \`catalog.schema_contract_gate\` by hand.`
+            ].join('\n');
+            const { data: open } = await github.rest.issues.listForRepo({ owner: context.repo.owner, repo: context.repo.repo, state: 'open', labels: LABEL, per_page: 100 });
+            const existing = open.find(issue => issue.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: existing.number, body });
+              core.warning(`${title} — commented on #${existing.number}`);
+              return;
+            }
+            const { data: created } = await github.rest.issues.create({ owner: context.repo.owner, repo: context.repo.repo, title, body, labels: [LABEL, 'automated'] });
+            core.warning(`${title} — opened #${created.number}`);
 
       - name: Deploy validation queries and stored procedures to all schemas
         env:
@@ -356,8 +412,9 @@ jobs:
               ### Recommended Actions
               1. Check the [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
               2. If migration failed, inspect each schema's \`schema_migrations\` ledger before retrying
-              3. If deployment failed, check Azure Portal for app service status and logs
-              4. Verify the app is running by logging in and testing functionality
+              3. A schema listed as BLOCKED in the gate summary passed the gate before and regressed on this deploy; quarantined schemas do not fail the deploy and are tracked under the \`schema-quarantine\` label
+              4. If deployment failed, check Azure Portal for app service status and logs
+              5. Verify the app is running by logging in and testing functionality
 
               > **Note**: The health endpoint requires authentication (Azure Easy Auth) and cannot be checked externally.
 

--- a/.github/workflows/dev-forestgeo-livesite.yml
+++ b/.github/workflows/dev-forestgeo-livesite.yml
@@ -288,7 +288,7 @@ jobs:
               ``,
               `The deploy continued for every other schema. Site-scoped API requests for these schemas return 503 \`SCHEMA_QUARANTINED\` until a later deploy passes the gate for them.`,
               ``,
-              `Repair: see "Quarantined schemas" in \`frontend/docs/deployment-to-development.md\`. Never edit \`catalog.schema_contract_gate\` by hand.`
+              `Repair: see \`docs/schema-contract-gate-quarantine.md\`. Never edit \`catalog.schema_contract_gate\` by hand.`
             ].join('\n');
             const { data: open } = await github.rest.issues.listForRepo({ owner: context.repo.owner, repo: context.repo.repo, state: 'open', labels: LABEL, per_page: 100 });
             const existing = open.find(issue => issue.title === title);

--- a/.github/workflows/main-forestgeo-livesite.yml
+++ b/.github/workflows/main-forestgeo-livesite.yml
@@ -227,9 +227,14 @@ jobs:
           npx tsx scripts/apply-catalog-migrations.ts --azure --apply
         continue-on-error: false
 
+      # A schema that has NEVER passed this gate and fails it is quarantined (the
+      # app refuses it with 503 SCHEMA_QUARANTINED) and the deploy continues; a
+      # schema that passed before and now fails still blocks the deploy. The
+      # result file feeds the "Report quarantined schemas" step below. See #429.
       - name: Apply schema migrations to all schemas
         env:
           AZURE_SQL_PASSWORD: ${{ secrets.AZURE_SQL_PASSWORD }}
+          SCHEMA_GATE_RESULT_PATH: ${{ runner.temp }}/schema-gate-result.json
         run: |
           cd frontend/
           npx tsx scripts/apply-schema-migrations.ts --all-sites --apply
@@ -242,6 +247,57 @@ jobs:
           cd frontend/
           npx tsx scripts/check-schema-contract.ts --all-sites
         continue-on-error: false
+
+      # Quarantine is not a failure, so nothing else would tell a human. Opens one
+      # issue per distinct set of quarantined schemas and comments on it while it
+      # stays open. Never blocks the deploy it reports on.
+      - name: Report quarantined schemas
+        if: always()
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          SCHEMA_GATE_RESULT_PATH: ${{ runner.temp }}/schema-gate-result.json
+        with:
+          script: |
+            const fs = require('fs');
+            const LABEL = 'schema-quarantine';
+            const resultPath = process.env.SCHEMA_GATE_RESULT_PATH;
+            if (!fs.existsSync(resultPath)) {
+              core.info('No schema gate result file; the apply step did not complete.');
+              return;
+            }
+            const result = JSON.parse(fs.readFileSync(resultPath, 'utf8'));
+            if (!Array.isArray(result.quarantined) || result.quarantined.length === 0) {
+              core.info('No schemas quarantined.');
+              return;
+            }
+            const names = result.quarantined.map(entry => entry.schema).sort();
+            const title = `Schema quarantined: ${names.join(', ')}`;
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const rows = result.quarantined.map(entry => `| \`${entry.schema}\` | ${entry.since} | ${entry.reason.split('\n')[0]} |`).join('\n');
+            const body = [
+              `## Schema contract gate quarantine`,
+              ``,
+              `**Run:** ${runUrl}`,
+              `**Branch:** ${context.ref}`,
+              ``,
+              `| Schema | Quarantined since | Reason (first line) |`,
+              `|---|---|---|`,
+              rows,
+              ``,
+              `The deploy continued for every other schema. Site-scoped API requests for these schemas return 503 \`SCHEMA_QUARANTINED\` until a later deploy passes the gate for them.`,
+              ``,
+              `Repair: see "Quarantined schemas" in \`frontend/docs/deployment-to-development.md\`. Never edit \`catalog.schema_contract_gate\` by hand.`
+            ].join('\n');
+            const { data: open } = await github.rest.issues.listForRepo({ owner: context.repo.owner, repo: context.repo.repo, state: 'open', labels: LABEL, per_page: 100 });
+            const existing = open.find(issue => issue.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: existing.number, body });
+              core.warning(`${title} — commented on #${existing.number}`);
+              return;
+            }
+            const { data: created } = await github.rest.issues.create({ owner: context.repo.owner, repo: context.repo.repo, title, body, labels: [LABEL, 'automated'] });
+            core.warning(`${title} — opened #${created.number}`);
 
       - name: Deploy validation queries and stored procedures to all schemas
         env:
@@ -355,8 +411,9 @@ jobs:
               ### Recommended Actions
               1. Check the [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
               2. If migration failed, inspect each schema's \`schema_migrations\` ledger before retrying
-              3. If deployment failed, check Azure Portal for app service status and logs
-              4. Verify the app is running by logging in and testing functionality
+              3. A schema listed as BLOCKED in the gate summary passed the gate before and regressed on this deploy; quarantined schemas do not fail the deploy and are tracked under the \`schema-quarantine\` label
+              4. If deployment failed, check Azure Portal for app service status and logs
+              5. Verify the app is running by logging in and testing functionality
 
               > **Note**: The health endpoint requires authentication (Azure Easy Auth) and cannot be checked externally.
 

--- a/.github/workflows/main-forestgeo-livesite.yml
+++ b/.github/workflows/main-forestgeo-livesite.yml
@@ -287,7 +287,7 @@ jobs:
               ``,
               `The deploy continued for every other schema. Site-scoped API requests for these schemas return 503 \`SCHEMA_QUARANTINED\` until a later deploy passes the gate for them.`,
               ``,
-              `Repair: see "Quarantined schemas" in \`frontend/docs/deployment-to-development.md\`. Never edit \`catalog.schema_contract_gate\` by hand.`
+              `Repair: see \`docs/schema-contract-gate-quarantine.md\`. Never edit \`catalog.schema_contract_gate\` by hand.`
             ].join('\n');
             const { data: open } = await github.rest.issues.listForRepo({ owner: context.repo.owner, repo: context.repo.repo, state: 'open', labels: LABEL, per_page: 100 });
             const existing = open.find(issue => issue.title === title);

--- a/docs/schema-contract-gate-quarantine.md
+++ b/docs/schema-contract-gate-quarantine.md
@@ -1,0 +1,72 @@
+# Quarantined schemas (deploy contract gate)
+
+Operational runbook for `catalog.schema_contract_gate` — what a quarantine means, how a
+schema gets released, and what to do when the deploy reports one. See issue #429.
+
+---
+
+## What the gate does
+
+The deploy job `migrate-and-verify-*` (in `.github/workflows/dev-forestgeo-livesite.yml` and
+`main-forestgeo-livesite.yml`) runs `apply-schema-migrations.ts --all-sites --apply` against
+every `forestgeo_*` schema. Per schema it records an outcome in `catalog.schema_contract_gate`:
+
+- **passed** — migrations applied and the contract audit is clean. `LastPassedAt` set, any
+  quarantine cleared.
+- **quarantined** — the schema has **never** passed and failed this run. The deploy continues
+  for every other schema; the procedure and view sweeps skip this one; site-scoped API
+  requests for it return `503 SCHEMA_QUARANTINED`. An issue labeled `schema-quarantine` is
+  opened by the workflow.
+- **BLOCKED** — the schema passed before and failed now: this deploy regressed it. The job
+  fails and nothing ships, exactly as before quarantine existed.
+
+If no schema passes, the job fails regardless (a bad migration must not ship as N quarantines).
+
+The gate table is created by the catalog migration
+`db/migrations/catalog/2026-09-02-01-schema-contract-gate.sql`, which the deploy applies in the
+step before the site gate. Until that has run on a server, the site gate refuses to start and
+names the catalog runner — that is correct fail-loud behavior, not an outage.
+
+## Bootstrap window
+
+On the first deploy after the gate table lands, every existing schema has no pass on record; a
+failure on that run quarantines instead of blocking. All live schemas were green on the
+previous deploy, so the expected outcome is that every schema is stamped passed. The window
+closes after one green run.
+
+## Repair and release
+
+1. Read the reason on the `schema-quarantine` issue or in `catalog.schema_contract_gate`.
+2. **Manifest gap** (the audit names an object no migration creates): add the migration to
+   `frontend/db/migrations/manifest.ts`, extend
+   `frontend/tests/integration/schema-manifest-convergence.integration.test.ts` (bump the
+   baseline fixture if the gap came from a shape it predates), merge. The next deploy converges
+   the schema and releases it. No manual step.
+3. **A migration failed on that schema only**: fix the data condition it named, redeploy.
+4. **The site is disposable**: tear it down from the provisioning admin page; the next
+   `--all-sites` run prunes its gate row.
+5. **Never hand-edit `QuarantinedAt`.** Release is earned by a passing gate run.
+
+## Checking status
+
+Read-only from a workstation (needs `AZURE_SQL_PASSWORD` in `frontend/.env.local`; writes
+nothing):
+
+```bash
+cd frontend && npx tsx scripts/apply-schema-migrations.ts --all-sites --check
+```
+
+Ends in `Check summary: N checked, Q quarantined`, with each quarantined schema printed above
+alongside the reason that put it there.
+
+## Where the behavior lives
+
+| Concern | File |
+|---|---|
+| Gate table DDL | `frontend/db/migrations/catalog/2026-09-02-01-schema-contract-gate.sql` |
+| Gate reads/writes for the CLIs | `frontend/scripts/lib/schema-gate.ts` |
+| Decision rule and apply loop | `frontend/scripts/apply-schema-migrations.ts` |
+| Read-only check | `frontend/scripts/check-schema-contract.ts` |
+| Sweeps that skip quarantined schemas | `frontend/scripts/deploy-validations-to-all-schemas.ts`, `deploy-taxonomy-views-to-all-schemas.ts` |
+| App-side lookup and 503 responses | `frontend/lib/schema-quarantine.ts` |
+| Enforcement chokepoints | `frontend/lib/route-authz.ts`, `frontend/lib/contextvalidation.ts` |

--- a/frontend/db/migrations/catalog-manifest.ts
+++ b/frontend/db/migrations/catalog-manifest.ts
@@ -21,6 +21,10 @@ export const CATALOG_MIGRATION_MANIFEST: readonly CatalogMigrationManifestEntry[
   {
     id: '2026-07-27-01-background-job-tables',
     file: 'catalog/2026-07-27-01-background-job-tables.sql'
+  },
+  {
+    id: '2026-09-02-01-schema-contract-gate',
+    file: 'catalog/2026-09-02-01-schema-contract-gate.sql'
   }
 ] as const;
 

--- a/frontend/db/migrations/catalog/2026-09-02-01-schema-contract-gate.sql
+++ b/frontend/db/migrations/catalog/2026-09-02-01-schema-contract-gate.sql
@@ -1,0 +1,41 @@
+-- =====================================================================================
+-- Catalog migration: schema contract gate
+-- =====================================================================================
+-- Ledger id: 2026-09-02-01-schema-contract-gate
+--
+-- Scope: the SHARED `catalog` database only. Runs exactly once per server through
+-- scripts/apply-catalog-migrations.ts, never once per forestgeo_* schema. The
+-- per-site manifest (db/migrations/manifest.ts) must never carry this id.
+--
+-- Purpose: one row per site schema recording the outcome of the deploy-time schema
+-- contract gate (scripts/apply-schema-migrations.ts --all-sites --apply).
+--   LastPassedAt      last time the schema passed migrate + audit
+--   LastFailedAt      last time it failed
+--   QuarantinedAt     set when a schema that has NEVER passed fails; cleared on pass
+--   QuarantineReason  the audit lines that caused the quarantine
+--   LastRunRef        Actions run URL, or local:<hostname>
+--
+-- A schema that has passed before and then fails is NOT quarantined: that is a
+-- regression this deploy introduced, so the gate blocks. Quarantine is only for a
+-- schema that has never reached a verified contract, so one such site cannot take
+-- the whole deploy down. See #429.
+--
+-- Written only by the deploy scripts (scripts/lib/schema-gate.ts). Read by
+-- check-schema-contract, the procedure and view sweeps, and lib/schema-quarantine.ts
+-- (API refusal). Every statement is additive and re-runnable.
+-- =====================================================================================
+
+CREATE DATABASE IF NOT EXISTS catalog CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS catalog.schema_contract_gate
+(
+    SchemaName       VARCHAR(64)  NOT NULL PRIMARY KEY,
+    LastPassedAt     DATETIME     NULL,
+    LastFailedAt     DATETIME     NULL,
+    QuarantinedAt    DATETIME     NULL,
+    QuarantineReason TEXT         NULL,
+    LastRunRef       VARCHAR(255) NULL,
+    UpdatedAt        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;

--- a/frontend/lib/contextvalidation.test.ts
+++ b/frontend/lib/contextvalidation.test.ts
@@ -24,6 +24,8 @@ vi.mock('@/ailogger', () => ({
 }));
 
 import { validateContextualValues } from '@/lib/contextvalidation';
+// Globally mocked in tests/mocks/db-mocks.ts; these cases drive it per test.
+import { findSchemaQuarantine } from '@/lib/schema-quarantine';
 
 const AUTHORIZED_SCHEMA = 'forestgeo_testing';
 const STATUS_UNAUTHENTICATED = 401;
@@ -138,6 +140,40 @@ describe('validateContextualValues — per-site schema authorization', () => {
     expect(result.success).toBe(true);
     expect(result.values?.schema).toBeUndefined();
     expect(authMock).not.toHaveBeenCalled();
+  });
+  it('refuses a quarantined schema with 503 SCHEMA_QUARANTINED after the access check', async () => {
+    authMock.mockResolvedValueOnce(sessionWithSites([AUTHORIZED_SCHEMA]));
+    vi.mocked(findSchemaQuarantine).mockResolvedValueOnce({
+      schemaName: AUTHORIZED_SCHEMA,
+      quarantinedAt: new Date('2026-09-02T18:04:11Z'),
+      reason: 'DRIFT',
+      runRef: null
+    });
+
+    const result = await validateContextualValues(makeRequest(AUTHORIZED_SCHEMA), { requireSchema: true });
+    const body = await result.response!.json();
+    console.log(`[ctx quarantined] status=${result.response!.status} body=${JSON.stringify(body)}`);
+
+    expect(result.success).toBe(false);
+    expect(result.response?.status).toBe(STATUS_SERVICE_UNAVAILABLE);
+    expect(body.code).toBe('SCHEMA_QUARANTINED');
+  });
+
+  it('never consults quarantine when requireSchemaAccess is false', async () => {
+    const result = await validateContextualValues(makeRequest(AUTHORIZED_SCHEMA), { requireSchema: true, requireSchemaAccess: false });
+
+    expect(result.success).toBe(true);
+    expect(findSchemaQuarantine).not.toHaveBeenCalled();
+  });
+
+  it('fails closed with 503 SCHEMA_GATE_UNAVAILABLE when the lookup throws', async () => {
+    authMock.mockResolvedValueOnce(sessionWithSites([AUTHORIZED_SCHEMA]));
+    vi.mocked(findSchemaQuarantine).mockRejectedValueOnce(new Error('catalog unreachable'));
+
+    const result = await validateContextualValues(makeRequest(AUTHORIZED_SCHEMA), { requireSchema: true });
+
+    expect(result.response?.status).toBe(STATUS_SERVICE_UNAVAILABLE);
+    expect((await result.response!.json()).code).toBe('SCHEMA_GATE_UNAVAILABLE');
   });
 });
 

--- a/frontend/lib/contextvalidation.ts
+++ b/frontend/lib/contextvalidation.ts
@@ -5,6 +5,7 @@ import ailogger from '@/ailogger';
 import { isValidSchema } from '@/lib/db/sqlsecurity';
 import { auth } from '@/auth';
 import { hasSchemaAccess, isAdminSession } from '@/lib/authz';
+import { findSchemaQuarantine, schemaGateUnavailableResponse, schemaQuarantinedResponse } from '@/lib/schema-quarantine';
 
 export interface ContextValues {
   siteID?: number;
@@ -152,6 +153,21 @@ export async function validateContextualValues(
             { status: HTTPResponses.FORBIDDEN }
           )
         };
+      }
+
+      // Quarantine is a schema-integrity state, not a permission: checked after
+      // the access check so an out-of-scope caller learns nothing, and admins are
+      // not exempt. See lib/schema-quarantine.ts and #429.
+      let quarantine;
+      try {
+        quarantine = await findSchemaQuarantine(values.schema);
+      } catch (error) {
+        ailogger.error(`[contextvalidation] schema quarantine lookup failed for '${values.schema}'`, error instanceof Error ? error : undefined);
+        return { success: false, response: schemaGateUnavailableResponse(error) };
+      }
+      if (quarantine) {
+        ailogger.warn(`[contextvalidation] Schema quarantined: ${values.schema}`);
+        return { success: false, response: schemaQuarantinedResponse(quarantine) };
       }
     }
 

--- a/frontend/lib/route-authz.test.ts
+++ b/frontend/lib/route-authz.test.ts
@@ -6,6 +6,8 @@ vi.mock('@/auth', () => ({ auth: vi.fn() }));
 import { auth } from '@/auth';
 import { withRouteAuthz, fromQuery, fromPath, fromPathSegment, fromBody } from '@/lib/route-authz';
 import type { RouteKey } from '@/lib/route-policy';
+// Globally mocked in tests/mocks/db-mocks.ts; these cases drive it per test.
+import { findSchemaQuarantine } from '@/lib/schema-quarantine';
 
 const HTTP_OK = 200;
 const HTTP_BAD_REQUEST = 400;
@@ -15,6 +17,12 @@ const HTTP_INTERNAL_SERVER_ERROR = 500;
 
 const ADMIN_ROLE = 'global';
 const NON_ADMIN_ROLE = 'field crew';
+
+const SCHEMA_QUARANTINED_CODE = 'SCHEMA_QUARANTINED';
+const SCHEMA_GATE_UNAVAILABLE_CODE = 'SCHEMA_GATE_UNAVAILABLE';
+const QUARANTINED_SCHEMA = 'forestgeo_serc';
+const quarantineRecord = { schemaName: QUARANTINED_SCHEMA, quarantinedAt: new Date('2026-09-02T18:04:11Z'), reason: 'DRIFT', runRef: null };
+const quarantinedRequest = () => new NextRequest(`http://localhost/api/validations/validationlist?schema=${QUARANTINED_SCHEMA}`);
 
 const makeHandler = () => vi.fn(async () => new Response('ok', { status: HTTP_OK }));
 const emptyCtx = { params: Promise.resolve({}) };
@@ -162,5 +170,54 @@ describe('withRouteAuthz', () => {
     expect(handler).toHaveBeenCalledOnce();
     const payload = await res.json();
     expect(payload.echoedGridType).toBe('stems');
+  });
+  it('refuses a member session on a quarantined schema with 503 SCHEMA_QUARANTINED', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ user: { userStatus: NON_ADMIN_ROLE, sites: [{ schemaName: QUARANTINED_SCHEMA }] } } as any);
+    vi.mocked(findSchemaQuarantine).mockResolvedValueOnce(quarantineRecord);
+    const handler = makeHandler();
+    const wrapped = withRouteAuthz('validations/validationlist', handler, { schema: fromQuery('schema') });
+
+    const res = await wrapped(quarantinedRequest(), emptyCtx);
+    const body = await res.json();
+    console.log(`[quarantined route] status=${res.status} body=${JSON.stringify(body)}`);
+
+    expect(res.status).toBe(HTTP_SERVICE_UNAVAILABLE);
+    expect(body.code).toBe(SCHEMA_QUARANTINED_CODE);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('still returns 403 for a non-member on a quarantined schema (quarantine is checked after authz)', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ user: { userStatus: NON_ADMIN_ROLE, sites: [{ schemaName: 'forestgeo_panama' }] } } as any);
+    const wrapped = withRouteAuthz('validations/validationlist', makeHandler(), { schema: fromQuery('schema') });
+
+    const res = await wrapped(quarantinedRequest(), emptyCtx);
+
+    expect(res.status).toBe(HTTP_FORBIDDEN);
+    expect(findSchemaQuarantine).not.toHaveBeenCalled();
+  });
+
+  it('does not exempt admins from quarantine on a site-scoped route', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ user: { userStatus: ADMIN_ROLE, sites: [] } } as any);
+    vi.mocked(findSchemaQuarantine).mockResolvedValueOnce(quarantineRecord);
+    const handler = makeHandler();
+    const wrapped = withRouteAuthz('validations/validationlist', handler, { schema: fromQuery('schema') });
+
+    const res = await wrapped(quarantinedRequest(), emptyCtx);
+
+    expect(res.status).toBe(HTTP_SERVICE_UNAVAILABLE);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('fails closed with 503 SCHEMA_GATE_UNAVAILABLE when the lookup throws', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ user: { userStatus: NON_ADMIN_ROLE, sites: [{ schemaName: QUARANTINED_SCHEMA }] } } as any);
+    vi.mocked(findSchemaQuarantine).mockRejectedValueOnce(new Error('catalog unreachable'));
+    const handler = makeHandler();
+    const wrapped = withRouteAuthz('validations/validationlist', handler, { schema: fromQuery('schema') });
+
+    const res = await wrapped(quarantinedRequest(), emptyCtx);
+
+    expect(res.status).toBe(HTTP_SERVICE_UNAVAILABLE);
+    expect((await res.json()).code).toBe(SCHEMA_GATE_UNAVAILABLE_CODE);
+    expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/frontend/lib/route-authz.ts
+++ b/frontend/lib/route-authz.ts
@@ -5,6 +5,7 @@ import { requireAdmin, requireSession } from '@/lib/auth-helpers';
 import { isValidSchema } from '@/lib/db/sqlsecurity';
 import { ROUTE_POLICIES, type RouteKey } from '@/lib/route-policy';
 import { HTTPResponses } from '@/config/macros';
+import { findSchemaQuarantine, schemaGateUnavailableResponse, schemaQuarantinedResponse } from '@/lib/schema-quarantine';
 import ailogger from '@/ailogger';
 
 export interface RouteContext {
@@ -75,7 +76,9 @@ type Handler = (request: NextRequest, context: RouteContext) => Promise<Response
  *   - `admin`       → requires an admin session (403 otherwise).
  *   - `site-scoped` → resolves a schema via `options.schema` and enforces
  *                     per-site access (400 on missing/invalid schema, 403 on
- *                     out-of-scope, 503 when permissions are unavailable).
+ *                     out-of-scope, 503 when permissions are unavailable), then
+ *                     503 SCHEMA_QUARANTINED when the schema is quarantined by
+ *                     the deploy contract gate (see lib/schema-quarantine.ts).
  *
  * The schema is resolved by an EXPLICIT per-route resolver
  * ({@link fromQuery}/{@link fromPath}/{@link fromBody}), never inferred from
@@ -117,6 +120,17 @@ export function withRouteAuthz(routeKey: RouteKey, handler: Handler, options: Au
     }
     const denied = assertSchemaAccess(session, schema);
     if (denied) return denied;
+
+    // Quarantine is a schema-integrity state, not a permission: it is checked only
+    // after authz so an out-of-scope caller learns nothing, and admins are not exempt.
+    let quarantine;
+    try {
+      quarantine = await findSchemaQuarantine(schema);
+    } catch (error) {
+      ailogger.error(`[route-authz] schema quarantine lookup failed for '${schema}' on '${routeKey}'`, error instanceof Error ? error : undefined);
+      return schemaGateUnavailableResponse(error);
+    }
+    if (quarantine) return schemaQuarantinedResponse(quarantine);
 
     return handler(request, routeContext);
   };

--- a/frontend/lib/schema-quarantine.test.ts
+++ b/frontend/lib/schema-quarantine.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The global unit setup (tests/mocks/db-mocks.ts) mocks this module so route
+// suites never hit the catalog. This file tests the real thing.
+vi.unmock('@/lib/schema-quarantine');
+
+import ailogger from '@/ailogger';
+import {
+  SCHEMA_GATE_UNAVAILABLE_CODE,
+  SCHEMA_QUARANTINED_CODE,
+  SCHEMA_QUARANTINE_CACHE_TTL_MS,
+  findSchemaQuarantine,
+  invalidateSchemaQuarantineCache,
+  schemaGateUnavailableResponse,
+  schemaQuarantinedResponse,
+  type QuarantineRecord
+} from '@/lib/schema-quarantine';
+
+const STATUS_SERVICE_UNAVAILABLE = 503;
+const ER_NO_SUCH_TABLE = 1146;
+const ER_LOCK_WAIT_TIMEOUT = 1205;
+
+function record(overrides: Partial<QuarantineRecord> = {}): QuarantineRecord {
+  return {
+    schemaName: 'forestgeo_new',
+    quarantinedAt: new Date('2026-09-02T18:04:11Z'),
+    reason: 'DRIFT [stems] column "PublishedStemID" missing',
+    runRef: 'run-url',
+    ...overrides
+  };
+}
+
+function mysqlError(errno: number): Error {
+  const error = new Error(`mysql ${errno}`) as Error & { errno: number };
+  error.errno = errno;
+  return error;
+}
+
+describe('schema-quarantine', () => {
+  beforeEach(() => {
+    invalidateSchemaQuarantineCache();
+    vi.clearAllMocks();
+  });
+
+  it('matches schema names case-insensitively', async () => {
+    const reader = vi.fn(async () => [record()]);
+
+    const found = await findSchemaQuarantine('FORESTGEO_NEW', reader);
+    console.log(`[quarantine lookup] found=${JSON.stringify(found)}`);
+
+    expect(found?.schemaName).toBe('forestgeo_new');
+    expect(await findSchemaQuarantine('forestgeo_serc', reader)).toBeNull();
+  });
+
+  it('caches for the TTL and re-reads after invalidation', async () => {
+    const reader = vi.fn(async () => [record()]);
+    const start = 1_000_000;
+
+    await findSchemaQuarantine('forestgeo_new', reader, start);
+    await findSchemaQuarantine('forestgeo_new', reader, start + SCHEMA_QUARANTINE_CACHE_TTL_MS - 1);
+    expect(reader).toHaveBeenCalledTimes(1);
+
+    await findSchemaQuarantine('forestgeo_new', reader, start + SCHEMA_QUARANTINE_CACHE_TTL_MS + 1);
+    expect(reader).toHaveBeenCalledTimes(2);
+
+    invalidateSchemaQuarantineCache();
+    await findSchemaQuarantine('forestgeo_new', reader, start + SCHEMA_QUARANTINE_CACHE_TTL_MS + 2);
+    expect(reader).toHaveBeenCalledTimes(3);
+  });
+
+  it('treats a missing gate table as "nothing quarantined" and warns once', async () => {
+    const reader = vi.fn(async () => {
+      throw mysqlError(ER_NO_SUCH_TABLE);
+    });
+
+    expect(await findSchemaQuarantine('forestgeo_new', reader)).toBeNull();
+    invalidateSchemaQuarantineCache();
+    expect(await findSchemaQuarantine('forestgeo_new', reader)).toBeNull();
+
+    console.log(`[quarantine missing-table] reads=${reader.mock.calls.length} warns=${vi.mocked(ailogger.warn).mock.calls.length}`);
+    expect(reader).toHaveBeenCalledTimes(2);
+    // The warn flag is process-lifetime on purpose: invalidating the cache must
+    // not re-arm a log line that would then repeat on every request.
+    expect(vi.mocked(ailogger.warn)).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates every other reader error', async () => {
+    const reader = vi.fn(async () => {
+      throw mysqlError(ER_LOCK_WAIT_TIMEOUT);
+    });
+
+    await expect(findSchemaQuarantine('forestgeo_new', reader)).rejects.toThrow(/1205/);
+  });
+
+  it('does not cache a propagated failure, so the next request retries the gate', async () => {
+    const failing = vi.fn(async (): Promise<QuarantineRecord[]> => {
+      throw mysqlError(ER_LOCK_WAIT_TIMEOUT);
+    });
+    await expect(findSchemaQuarantine('forestgeo_new', failing)).rejects.toThrow(/1205/);
+
+    const recovered = vi.fn(async () => [record()]);
+    expect((await findSchemaQuarantine('forestgeo_new', recovered))?.schemaName).toBe('forestgeo_new');
+    expect(recovered).toHaveBeenCalledTimes(1);
+  });
+
+  it('builds the 503 responses with their codes', async () => {
+    const quarantined = schemaQuarantinedResponse(record());
+    expect(quarantined.status).toBe(STATUS_SERVICE_UNAVAILABLE);
+
+    const body = await quarantined.json();
+    console.log(`[quarantined body] ${JSON.stringify(body)}`);
+    expect(body).toMatchObject({
+      code: SCHEMA_QUARANTINED_CODE,
+      schema: 'forestgeo_new',
+      quarantinedAt: '2026-09-02T18:04:11.000Z',
+      runRef: 'run-url'
+    });
+    expect(body.error).toMatch(/quarantined/);
+    expect(body.error).toMatch(/released automatically/);
+
+    const unavailable = schemaGateUnavailableResponse(new Error('boom'));
+    expect(unavailable.status).toBe(STATUS_SERVICE_UNAVAILABLE);
+    expect(await unavailable.json()).toMatchObject({ code: SCHEMA_GATE_UNAVAILABLE_CODE });
+  });
+});

--- a/frontend/lib/schema-quarantine.ts
+++ b/frontend/lib/schema-quarantine.ts
@@ -1,0 +1,125 @@
+/**
+ * App-side view of catalog.schema_contract_gate (see #429).
+ *
+ * A quarantined schema failed the deploy contract gate and has never passed it,
+ * so the running app code may be incompatible with it. Site-scoped routes refuse
+ * such schemas with 503 SCHEMA_QUARANTINED until a later deploy passes the gate
+ * and clears QuarantinedAt. The table is written only by scripts/apply-schema-
+ * migrations.ts; this module only reads it.
+ *
+ * Node runtime only: never import from lib/authz.ts or middleware.
+ */
+
+import { NextResponse } from 'next/server';
+import ConnectionManager from '@/lib/db/connectionmanager';
+import { HTTPResponses } from '@/config/macros';
+import ailogger from '@/ailogger';
+
+export const SCHEMA_QUARANTINE_CACHE_TTL_MS = 60_000;
+export const SCHEMA_QUARANTINED_CODE = 'SCHEMA_QUARANTINED';
+export const SCHEMA_GATE_UNAVAILABLE_CODE = 'SCHEMA_GATE_UNAVAILABLE';
+
+const SCHEMA_GATE_TABLE = 'catalog.schema_contract_gate';
+const ER_NO_SUCH_TABLE = 1146;
+const QUARANTINED_SCHEMAS_QUERY = `SELECT SchemaName, QuarantinedAt, QuarantineReason, LastRunRef FROM ${SCHEMA_GATE_TABLE} WHERE QuarantinedAt IS NOT NULL`;
+
+export interface QuarantineRecord {
+  schemaName: string;
+  quarantinedAt: Date;
+  reason: string;
+  runRef: string | null;
+}
+
+export type QuarantineReader = () => Promise<QuarantineRecord[]>;
+
+interface QuarantineCache {
+  records: Map<string, QuarantineRecord>;
+  expiresAt: number;
+}
+
+let cache: QuarantineCache | null = null;
+let missingTableWarned = false;
+
+function isNoSuchTableError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && (error as { errno?: unknown }).errno === ER_NO_SUCH_TABLE;
+}
+
+function warnMissingGateTableOnce(): void {
+  if (missingTableWarned) return;
+  ailogger.warn(`[schema-quarantine] ${SCHEMA_GATE_TABLE} does not exist; catalog migrations have not run on this server. Treating no schema as quarantined.`);
+  missingTableWarned = true;
+}
+
+function toRecord(row: Record<string, unknown>): QuarantineRecord {
+  return {
+    schemaName: String(row.SchemaName),
+    quarantinedAt: row.QuarantinedAt instanceof Date ? row.QuarantinedAt : new Date(String(row.QuarantinedAt)),
+    reason: row.QuarantineReason === null || row.QuarantineReason === undefined ? '' : String(row.QuarantineReason),
+    runRef: row.LastRunRef === null || row.LastRunRef === undefined ? null : String(row.LastRunRef)
+  };
+}
+
+async function readQuarantinedFromCatalog(): Promise<QuarantineRecord[]> {
+  const connectionManager = ConnectionManager.getInstance();
+  try {
+    const rows = await connectionManager.executeQuery(QUARANTINED_SCHEMAS_QUERY);
+    return (Array.isArray(rows) ? (rows as Record<string, unknown>[]) : []).map(toRecord);
+  } finally {
+    await connectionManager.closeConnection();
+  }
+}
+
+async function loadQuarantined(reader: QuarantineReader, now: number): Promise<Map<string, QuarantineRecord>> {
+  if (cache && cache.expiresAt > now) return cache.records;
+
+  let records: QuarantineRecord[];
+  try {
+    records = await reader();
+  } catch (error) {
+    // A server whose catalog migrations have not run yet has no gate table. That
+    // is the ONLY tolerated failure: anything else (auth, timeout, connectivity)
+    // must reach the caller, which fails the request closed with a 503.
+    if (!isNoSuchTableError(error)) throw error;
+    warnMissingGateTableOnce();
+    records = [];
+  }
+
+  cache = { records: new Map(records.map(record => [record.schemaName.toLowerCase(), record])), expiresAt: now + SCHEMA_QUARANTINE_CACHE_TTL_MS };
+  return cache.records;
+}
+
+export async function findSchemaQuarantine(
+  schema: string,
+  reader: QuarantineReader = readQuarantinedFromCatalog,
+  now: number = Date.now()
+): Promise<QuarantineRecord | null> {
+  const records = await loadQuarantined(reader, now);
+  return records.get(schema.toLowerCase()) ?? null;
+}
+
+export function invalidateSchemaQuarantineCache(): void {
+  cache = null;
+}
+
+export function schemaQuarantinedResponse(record: QuarantineRecord): NextResponse {
+  const quarantinedAt = record.quarantinedAt.toISOString();
+  return NextResponse.json(
+    {
+      error: `Site ${record.schemaName} is quarantined: its database schema failed the deploy contract gate on ${quarantinedAt}. It is released automatically when a deploy passes.`,
+      code: SCHEMA_QUARANTINED_CODE,
+      schema: record.schemaName,
+      quarantinedAt,
+      reason: record.reason,
+      runRef: record.runRef
+    },
+    { status: HTTPResponses.SERVICE_UNAVAILABLE }
+  );
+}
+
+export function schemaGateUnavailableResponse(error: unknown): NextResponse {
+  const detail = error instanceof Error ? error.message : String(error);
+  return NextResponse.json(
+    { error: `schema contract gate unavailable: ${detail}`, code: SCHEMA_GATE_UNAVAILABLE_CODE },
+    { status: HTTPResponses.SERVICE_UNAVAILABLE }
+  );
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "lint": "next lint --fix --quiet && prettier --write .",
     "format": "prettier --write .",
     "test:unit": "node ./scripts/run-vitest-unit.mjs",
-    "test:unit:ci": "node ./scripts/run-vitest-unit.mjs app components config lib testing tests/loading-duplicate-prevention.test.tsx tests/upload-procedure-regressions.test.ts tests/column-mapping-contract.test.ts",
+    "test:unit:ci": "node ./scripts/run-vitest-unit.mjs app components config lib testing tests/loading-duplicate-prevention.test.tsx tests/upload-procedure-regressions.test.ts tests/column-mapping-contract.test.ts tests/ddl-environment-neutrality.test.ts",
     "test:unit:raw": "node --max-old-space-size=4096 ./node_modules/vitest/vitest.mjs run",
     "test:integration": "node --max-old-space-size=4096 ./node_modules/vitest/vitest.mjs run --config vitest.integration.config.mts",
     "test:integration:azure": "dotenv -e .env.testing.azure -- node --max-old-space-size=4096 ./node_modules/vitest/vitest.mjs run --config vitest.integration.config.mts",

--- a/frontend/scripts/apply-catalog-migrations.test.ts
+++ b/frontend/scripts/apply-catalog-migrations.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   applyPendingCatalogMigrations,
-  CATALOG_BACKGROUND_JOB_TABLES,
+  CATALOG_OWNED_TABLES,
   CATALOG_LEDGER_TABLE,
   CATALOG_MIGRATION_LOCK_NAME,
   CatalogTablesNotEmptyError,
@@ -24,9 +24,11 @@ import { SCHEMA_MIGRATION_MANIFEST } from '../db/migrations/manifest';
 import { TamperedMigrationError, type MigrationSource } from './apply-schema-migrations';
 
 const BACKGROUND_JOBS = 'background_jobs';
+const SCHEMA_CONTRACT_GATE = 'schema_contract_gate';
+const GATE_COLUMNS = ['SchemaName', 'LastPassedAt', 'LastFailedAt', 'QuarantinedAt', 'QuarantineReason', 'LastRunRef', 'UpdatedAt'];
 
 /** Columns matching the canonical migration for a given table. */
-function currentColumns(table: (typeof CATALOG_BACKGROUND_JOB_TABLES)[number]): LiveColumn[] {
+function currentColumns(table: (typeof CATALOG_OWNED_TABLES)[number]): LiveColumn[] {
   if (table === BACKGROUND_JOBS) {
     return [
       { name: 'JobID', columnType: 'bigint' },
@@ -85,11 +87,14 @@ function currentColumns(table: (typeof CATALOG_BACKGROUND_JOB_TABLES)[number]): 
       ].map(name => ({ name, columnType: 'varchar(64)' }))
     ];
   }
+  if (table === SCHEMA_CONTRACT_GATE) {
+    return GATE_COLUMNS.map(name => ({ name, columnType: 'varchar(64)' }));
+  }
   return ['EventID', 'JobID', 'EventType', 'Message', 'Details', 'CreatedAt'].map(name => ({ name, columnType: 'varchar(64)' }));
 }
 
 /** Indexes matching the canonical migration for a given table. */
-function currentIndexes(table: (typeof CATALOG_BACKGROUND_JOB_TABLES)[number]): LiveIndex[] {
+function currentIndexes(table: (typeof CATALOG_OWNED_TABLES)[number]): LiveIndex[] {
   return CATALOG_TABLE_CONTRACTS[table].requiredIndexes.map(index => ({
     name: index.name,
     columns: [...index.columns],
@@ -103,7 +108,7 @@ function makeSource(overrides: Partial<MigrationSource> = {}): MigrationSource {
 
 function cleanPreflight(): CatalogPreflight {
   return {
-    tables: CATALOG_BACKGROUND_JOB_TABLES.map(table => ({ table, state: 'absent' as const, differences: [], rowCount: null })),
+    tables: CATALOG_OWNED_TABLES.map(table => ({ table, state: 'absent' as const, differences: [], rowCount: null })),
     hasStale: false,
     staleRowTotal: 0
   };
@@ -233,7 +238,7 @@ describe('classifyCatalogTable — index contract', () => {
   });
 
   it('accepts the canonical index set for every owned table', () => {
-    for (const table of CATALOG_BACKGROUND_JOB_TABLES) {
+    for (const table of CATALOG_OWNED_TABLES) {
       expect(classifyCatalogTable(table, currentColumns(table), currentIndexes(table)).state).toBe('current');
     }
   });
@@ -258,12 +263,12 @@ describe('runCatalogPreflight', () => {
   it('reports stale tables with their row counts', async () => {
     const exec = vi.fn(async (sql: string, params?: unknown[]) => {
       if (sql.includes('information_schema.COLUMNS')) {
-        const table = String((params as unknown[])[1]) as (typeof CATALOG_BACKGROUND_JOB_TABLES)[number];
+        const table = String((params as unknown[])[1]) as (typeof CATALOG_OWNED_TABLES)[number];
         if (table !== BACKGROUND_JOBS) return currentColumns(table).map(column => ({ name: column.name, columnType: column.columnType }));
         return [...currentColumns(BACKGROUND_JOBS), { name: 'LastMessageID', columnType: 'varchar(128)' }];
       }
       if (sql.includes('information_schema.STATISTICS')) {
-        const table = String((params as unknown[])[1]) as (typeof CATALOG_BACKGROUND_JOB_TABLES)[number];
+        const table = String((params as unknown[])[1]) as (typeof CATALOG_OWNED_TABLES)[number];
         return currentIndexes(table).map(index => ({ name: index.name, nonUnique: index.unique ? 0 : 1, columns: index.columns.join(',') }));
       }
       if (sql.includes('COUNT(*)')) return [{ rowCount: sql.includes('background_jobs`') ? 7 : 0 }];
@@ -371,7 +376,8 @@ describe('remediateEmptyUnreleasedCatalogTables', () => {
       tables: [
         { table: 'background_job_events', state: 'absent', differences: [], rowCount: null },
         { table: 'background_job_files', state: 'absent', differences: [], rowCount: null },
-        { table: BACKGROUND_JOBS, state: 'stale', differences: ['legacy column LastMessageID present'], rowCount: 0 }
+        { table: BACKGROUND_JOBS, state: 'stale', differences: ['legacy column LastMessageID present'], rowCount: 0 },
+        { table: SCHEMA_CONTRACT_GATE, state: 'absent', differences: [], rowCount: null }
       ],
       hasStale: true,
       staleRowTotal: 0
@@ -380,10 +386,11 @@ describe('remediateEmptyUnreleasedCatalogTables', () => {
     const dropped = await remediateEmptyUnreleasedCatalogTables(exec as never, stale);
 
     // Children before the parent so FKs never block the drop.
-    expect(dropped).toEqual(['background_job_events', 'background_job_files', 'background_jobs']);
+    expect(dropped).toEqual([...CATALOG_OWNED_TABLES]);
     const droppedOrder = exec.mock.calls.map(([sql]) => String(sql)).filter(sql => sql.startsWith('DROP TABLE'));
     expect(droppedOrder[0]).toContain('background_job_events');
     expect(droppedOrder[2]).toContain('background_jobs');
+    expect(droppedOrder[3]).toContain(SCHEMA_CONTRACT_GATE);
   });
 
   it('refuses to drop when any owned table holds rows', async () => {
@@ -418,5 +425,29 @@ describe('parseCatalogRunnerArgs', () => {
 
   it('rejects an unknown flag rather than silently ignoring it', () => {
     expect(() => parseCatalogRunnerArgs(['--check', '--all-sites'])).toThrow(/Unknown argument/);
+  });
+});
+
+describe('classifyCatalogTable — schema_contract_gate', () => {
+  it('is absent when no columns exist', () => {
+    expect(classifyCatalogTable(SCHEMA_CONTRACT_GATE, null).state).toBe('absent');
+  });
+
+  it('is current with the seven contract columns', () => {
+    const result = classifyCatalogTable(SCHEMA_CONTRACT_GATE, currentColumns(SCHEMA_CONTRACT_GATE), currentIndexes(SCHEMA_CONTRACT_GATE));
+    console.log(`[gate classify] state=${result.state} differences=${JSON.stringify(result.differences)}`);
+    expect(result.state).toBe('current');
+  });
+
+  it('is stale when QuarantinedAt is missing', () => {
+    const columns = currentColumns(SCHEMA_CONTRACT_GATE).filter(column => column.name !== 'QuarantinedAt');
+    const result = classifyCatalogTable(SCHEMA_CONTRACT_GATE, columns, currentIndexes(SCHEMA_CONTRACT_GATE));
+    console.log(`[gate classify] state=${result.state} differences=${JSON.stringify(result.differences)}`);
+    expect(result.state).toBe('stale');
+    expect(result.differences.some(difference => difference.includes('QuarantinedAt'))).toBe(true);
+  });
+
+  it('is the last owned table so the drop order stays foreign-key safe', () => {
+    expect(CATALOG_OWNED_TABLES[CATALOG_OWNED_TABLES.length - 1]).toBe(SCHEMA_CONTRACT_GATE);
   });
 });

--- a/frontend/scripts/apply-catalog-migrations.ts
+++ b/frontend/scripts/apply-catalog-migrations.ts
@@ -73,10 +73,14 @@ export const CATALOG_LEDGER_TABLE = 'catalog_migrations';
  */
 export const CATALOG_MIGRATION_LOCK_NAME = 'fg:migrate:catalog';
 
-/** Tables this migration set owns, in foreign-key-safe DROP order (children first). */
-export const CATALOG_BACKGROUND_JOB_TABLES = ['background_job_events', 'background_job_files', 'background_jobs'] as const;
+/**
+ * Tables the catalog manifest owns, in foreign-key-safe DROP order (children
+ * first). schema_contract_gate has no foreign keys and is written by the site
+ * gate (see scripts/lib/schema-gate.ts), so it goes last.
+ */
+export const CATALOG_OWNED_TABLES = ['background_job_events', 'background_job_files', 'background_jobs', 'schema_contract_gate'] as const;
 
-export type CatalogTableName = (typeof CATALOG_BACKGROUND_JOB_TABLES)[number];
+export type CatalogTableName = (typeof CATALOG_OWNED_TABLES)[number];
 
 /**
  * Minimum shape each table must have to be considered CURRENT. Only
@@ -190,6 +194,15 @@ export const CATALOG_TABLE_CONTRACTS: Readonly<Record<CatalogTableName, CatalogT
     forbiddenColumns: [],
     enumValues: {},
     requiredIndexes: [{ name: 'idx_background_job_events_job_created', columns: ['JobID', 'CreatedAt'], unique: false }]
+  },
+  schema_contract_gate: {
+    requiredColumns: ['SchemaName', 'LastPassedAt', 'LastFailedAt', 'QuarantinedAt', 'QuarantineReason', 'LastRunRef', 'UpdatedAt'],
+    forbiddenColumns: [],
+    enumValues: {},
+    // The primary key on SchemaName is what makes one row per schema; it is
+    // created by the table definition itself, so there is no secondary index
+    // the gate's correctness depends on.
+    requiredIndexes: []
   }
 } as const;
 
@@ -367,7 +380,7 @@ export function classifyCatalogTable(table: CatalogTableName, columns: LiveColum
 export async function runCatalogPreflight(exec: SqlExecutor, database: string = CATALOG_DATABASE_NAME): Promise<CatalogPreflight> {
   const tables: CatalogTablePreflight[] = [];
 
-  for (const table of CATALOG_BACKGROUND_JOB_TABLES) {
+  for (const table of CATALOG_OWNED_TABLES) {
     const columnRows = await exec(
       `SELECT COLUMN_NAME AS name, COLUMN_TYPE AS columnType FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?`,
       [database, table]
@@ -569,7 +582,7 @@ export async function remediateEmptyUnreleasedCatalogTables(
 
   const dropped: CatalogTableName[] = [];
   // Children first so the foreign keys never block the parent drop.
-  for (const table of CATALOG_BACKGROUND_JOB_TABLES) {
+  for (const table of CATALOG_OWNED_TABLES) {
     await exec(`DROP TABLE IF EXISTS \`${database}\`.\`${table}\``);
     dropped.push(table);
   }

--- a/frontend/scripts/apply-schema-migrations.test.ts
+++ b/frontend/scripts/apply-schema-migrations.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import type { SchemaQueryRow } from '@/lib/db/schema-contract';
 import {
   sha256Hex,
@@ -9,6 +12,13 @@ import {
   migrationLockName,
   contractGateFailed,
   parseRunnerArgs,
+  decideGateOutcome,
+  runApplyGateLoop,
+  formatGateReason,
+  formatGitHubAnnotations,
+  writeGateResultFile,
+  GATE_RESULT_PATH_ENV,
+  ERROR_SUMMARY_MAX_LENGTH,
   TamperedMigrationError,
   NoSiteSchemasError,
   MIGRATION_STATUS,
@@ -17,8 +27,12 @@ import {
   type ContractAudit,
   type MigrationSource,
   type LedgerRow,
-  type SqlExecutor
+  type SqlExecutor,
+  type GateStore,
+  type SchemaGateResult,
+  type GateRunSummary
 } from './apply-schema-migrations';
+import type { SchemaGateRow } from './lib/schema-gate';
 
 function source(id: string, contents: string): MigrationSource {
   return { id, file: `${id}.sql`, contents, checksum: sha256Hex(contents), failureCleanup: [] };
@@ -236,5 +250,199 @@ describe('parseRunnerArgs', () => {
 
   it('rejects a --schema with no value', () => {
     expect(() => parseRunnerArgs(['--apply', '--schema'])).toThrow(/requires a schema name/);
+  });
+});
+
+function gateRow(overrides: Partial<SchemaGateRow> = {}): SchemaGateRow {
+  return { schemaName: 'forestgeo_x', lastPassedAt: null, lastFailedAt: null, quarantinedAt: null, quarantineReason: null, lastRunRef: null, ...overrides };
+}
+
+/** Records every gate write so tests can assert exactly what the loop persisted. */
+class FakeGateStore implements GateStore {
+  rows = new Map<string, SchemaGateRow>();
+  passes: string[] = [];
+  quarantines: Array<{ schema: string; reason: string }> = [];
+  blocks: string[] = [];
+  readonly quarantinedSince = new Date('2026-09-02T18:04:11Z');
+
+  async pass(schema: string): Promise<void> {
+    this.passes.push(schema);
+  }
+  async quarantine(schema: string, reason: string): Promise<Date> {
+    this.quarantines.push({ schema, reason });
+    return this.quarantinedSince;
+  }
+  async block(schema: string): Promise<void> {
+    this.blocks.push(schema);
+  }
+}
+
+describe('decideGateOutcome', () => {
+  it('passes a passing schema regardless of history', () => {
+    expect(decideGateOutcome(true, null)).toBe('passed');
+    expect(decideGateOutcome(true, gateRow({ lastPassedAt: new Date() }))).toBe('passed');
+  });
+
+  it('quarantines a failing schema that has never passed', () => {
+    expect(decideGateOutcome(false, null)).toBe('quarantined');
+    expect(decideGateOutcome(false, gateRow({ lastPassedAt: null, quarantinedAt: new Date() }))).toBe('quarantined');
+  });
+
+  it('blocks a failing schema that passed before', () => {
+    expect(decideGateOutcome(false, gateRow({ lastPassedAt: new Date('2026-08-01T00:00:00Z') }))).toBe('blocked');
+  });
+});
+
+describe('runApplyGateLoop', () => {
+  function processor(results: Record<string, SchemaGateResult>) {
+    const calls: string[] = [];
+    const processOne = async (schema: string): Promise<SchemaGateResult> => {
+      calls.push(schema);
+      return results[schema];
+    };
+    return { processOne, calls };
+  }
+
+  it('continues past a never-passed failing schema and records the quarantine', async () => {
+    const logs: string[] = [];
+    const store = new FakeGateStore();
+    const { processOne, calls } = processor({
+      forestgeo_a: { schema: 'forestgeo_a', passed: true, reason: '' },
+      forestgeo_new: { schema: 'forestgeo_new', passed: false, reason: 'DRIFT [stems] column "PublishedStemID" missing' },
+      forestgeo_z: { schema: 'forestgeo_z', passed: true, reason: '' }
+    });
+
+    const { summary, exitCode } = await runApplyGateLoop(['forestgeo_a', 'forestgeo_new', 'forestgeo_z'], processOne, store, line => logs.push(line));
+    console.log(`[gate loop] exit=${exitCode} summary=${JSON.stringify(summary)}`);
+
+    expect(calls).toEqual(['forestgeo_a', 'forestgeo_new', 'forestgeo_z']);
+    expect(exitCode).toBe(0);
+    expect(summary.passed).toEqual(['forestgeo_a', 'forestgeo_z']);
+    expect(summary.quarantined).toEqual([
+      { schema: 'forestgeo_new', reason: 'DRIFT [stems] column "PublishedStemID" missing', since: store.quarantinedSince.toISOString() }
+    ]);
+    expect(summary.blocked).toEqual([]);
+    expect(store.passes).toEqual(['forestgeo_a', 'forestgeo_z']);
+    expect(store.quarantines).toEqual([{ schema: 'forestgeo_new', reason: 'DRIFT [stems] column "PublishedStemID" missing' }]);
+  });
+
+  it('stops at a previously-passed failing schema and exits 1', async () => {
+    const logs: string[] = [];
+    const store = new FakeGateStore();
+    store.rows.set('forestgeo_b', gateRow({ schemaName: 'forestgeo_b', lastPassedAt: new Date('2026-08-01T00:00:00Z') }));
+    const { processOne, calls } = processor({
+      forestgeo_a: { schema: 'forestgeo_a', passed: true, reason: '' },
+      forestgeo_b: { schema: 'forestgeo_b', passed: false, reason: 'MIGRATION FAILED 2026-09-x: boom' },
+      forestgeo_c: { schema: 'forestgeo_c', passed: true, reason: '' }
+    });
+
+    const { summary, exitCode } = await runApplyGateLoop(['forestgeo_a', 'forestgeo_b', 'forestgeo_c'], processOne, store, line => logs.push(line));
+    console.log(`[gate loop blocked] exit=${exitCode} calls=${JSON.stringify(calls)} summary=${JSON.stringify(summary)}`);
+
+    expect(calls).toEqual(['forestgeo_a', 'forestgeo_b']);
+    expect(exitCode).toBe(1);
+    expect(summary.blocked).toEqual([{ schema: 'forestgeo_b', reason: 'MIGRATION FAILED 2026-09-x: boom' }]);
+    expect(store.blocks).toEqual(['forestgeo_b']);
+    expect(store.quarantines).toEqual([]);
+  });
+
+  it('fails the run when no schema passed, even though each failure was quarantine-eligible', async () => {
+    const logs: string[] = [];
+    const store = new FakeGateStore();
+    const { processOne } = processor({
+      forestgeo_a: { schema: 'forestgeo_a', passed: false, reason: 'DRIFT a' },
+      forestgeo_b: { schema: 'forestgeo_b', passed: false, reason: 'DRIFT b' }
+    });
+
+    const { summary, exitCode } = await runApplyGateLoop(['forestgeo_a', 'forestgeo_b'], processOne, store, line => logs.push(line));
+    console.log(`[gate loop zero-pass] exit=${exitCode} logs=${JSON.stringify(logs)}`);
+
+    expect(exitCode).toBe(1);
+    expect(summary.quarantined.map(entry => entry.schema)).toEqual(['forestgeo_a', 'forestgeo_b']);
+    expect(logs.some(line => /no schema passed/i.test(line))).toBe(true);
+  });
+
+  it('treats a thrown per-schema error as a failure with the error message as reason', async () => {
+    const logs: string[] = [];
+    const store = new FakeGateStore();
+    const processOne = async (schema: string): Promise<SchemaGateResult> => {
+      if (schema === 'forestgeo_bad') throw new Error('ER_CANT_AGGREGATE_2COLLATIONS');
+      return { schema, passed: true, reason: '' };
+    };
+
+    const { summary } = await runApplyGateLoop(['forestgeo_bad', 'forestgeo_ok'], processOne, store, line => logs.push(line));
+
+    expect(summary.quarantined[0]).toMatchObject({ schema: 'forestgeo_bad', reason: 'ER_CANT_AGGREGATE_2COLLATIONS' });
+    expect(summary.passed).toEqual(['forestgeo_ok']);
+  });
+
+  it('matches prior gate rows case-insensitively so a mixed-case schema is not misread as never-passed', async () => {
+    const logs: string[] = [];
+    const store = new FakeGateStore();
+    store.rows.set('forestgeo_mixed', gateRow({ schemaName: 'forestgeo_Mixed', lastPassedAt: new Date('2026-08-01T00:00:00Z') }));
+    const { processOne } = processor({
+      forestgeo_Mixed: { schema: 'forestgeo_Mixed', passed: false, reason: 'DRIFT mixed' }
+    });
+
+    const { summary, exitCode } = await runApplyGateLoop(['forestgeo_Mixed'], processOne, store, line => logs.push(line));
+
+    expect(exitCode).toBe(1);
+    expect(summary.blocked.map(entry => entry.schema)).toEqual(['forestgeo_Mixed']);
+    expect(summary.quarantined).toEqual([]);
+  });
+});
+
+describe('gate reporting helpers', () => {
+  const summary: GateRunSummary = {
+    passed: ['forestgeo_a'],
+    quarantined: [{ schema: 'forestgeo_new', reason: 'DRIFT line 1\nDRIFT line 2', since: '2026-09-02T18:04:11.000Z' }],
+    blocked: []
+  };
+
+  it('truncates a reason at ERROR_SUMMARY_MAX_LENGTH', () => {
+    const audit: ContractAudit = {
+      schema: 's',
+      contractFailures: Array.from({ length: 200 }, (_, index) => ({
+        table: 'stems',
+        object: `col${index}`,
+        category: 'column' as const,
+        kind: 'missing' as const,
+        expected: 'int',
+        actual: null
+      })),
+      contractExtras: [],
+      collationViolations: [],
+      missingProcedures: [],
+      pendingMigrationIds: [],
+      ok: false
+    };
+
+    const reason = formatGateReason(audit, null);
+    console.log(`[gate reason] length=${reason.length} head=${reason.slice(0, 80)}`);
+
+    expect(reason.length).toBe(ERROR_SUMMARY_MAX_LENGTH);
+    expect(reason.startsWith('DRIFT')).toBe(true);
+  });
+
+  it('puts a migration failure ahead of any audit lines', () => {
+    const reason = formatGateReason(null, { id: '2026-09-02-01-x', error: 'Duplicate column name' });
+    expect(reason).toBe('MIGRATION FAILED 2026-09-02-01-x: Duplicate column name');
+  });
+
+  it('emits one warning annotation per quarantined schema with the first reason line', () => {
+    expect(formatGitHubAnnotations(summary)).toEqual(['::warning title=Schema quarantined::forestgeo_new — DRIFT line 1']);
+  });
+
+  it('writes the result file only when the env var is set', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-result-'));
+    const target = path.join(dir, 'result.json');
+
+    writeGateResultFile(summary, {});
+    expect(fs.existsSync(target)).toBe(false);
+
+    writeGateResultFile(summary, { [GATE_RESULT_PATH_ENV]: target });
+    expect(JSON.parse(fs.readFileSync(target, 'utf-8'))).toEqual(summary);
+
+    fs.rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/frontend/scripts/apply-schema-migrations.test.ts
+++ b/frontend/scripts/apply-schema-migrations.test.ts
@@ -390,6 +390,20 @@ describe('runApplyGateLoop', () => {
     expect(summary.blocked.map(entry => entry.schema)).toEqual(['forestgeo_Mixed']);
     expect(summary.quarantined).toEqual([]);
   });
+  it('skips the systemic-failure floor when the caller targets a single schema', async () => {
+    const logs: string[] = [];
+    const store = new FakeGateStore();
+    const { processOne } = processor({
+      forestgeo_only: { schema: 'forestgeo_only', passed: false, reason: 'DRIFT only' }
+    });
+
+    const { summary, exitCode } = await runApplyGateLoop(['forestgeo_only'], processOne, store, line => logs.push(line), false);
+    console.log(`[gate loop single-schema] exit=${exitCode} quarantined=${JSON.stringify(summary.quarantined.map(entry => entry.schema))}`);
+
+    expect(exitCode).toBe(0);
+    expect(summary.quarantined.map(entry => entry.schema)).toEqual(['forestgeo_only']);
+    expect(logs.some(line => /no schema passed/i.test(line))).toBe(false);
+  });
 });
 
 describe('gate reporting helpers', () => {

--- a/frontend/scripts/apply-schema-migrations.ts
+++ b/frontend/scripts/apply-schema-migrations.ts
@@ -472,14 +472,20 @@ export function formatGateReason(audit: ContractAudit | null, migrationFailure: 
 /**
  * Applies the per-schema outcome rule across every discovered schema. A
  * quarantined schema never stops the loop; a blocked schema stops it (today's
- * "abort remaining schemas" behavior) and fails the run; zero passing schemas
- * fails the run regardless, so a bad migration cannot ship as N quarantines.
+ * "abort remaining schemas" behavior) and fails the run.
+ *
+ * `requireAtLeastOnePass` is the systemic-failure floor for the deploy sweep: if
+ * a bad migration breaks every schema at once, the run must fail rather than ship
+ * the app with every site quarantined. It is meaningless for a single-schema run,
+ * where "no schema passed" just restates the one outcome the caller asked for, so
+ * runCli enables it only for --all-sites.
  */
 export async function runApplyGateLoop(
   schemas: string[],
   processOne: (schema: string) => Promise<SchemaGateResult>,
   store: GateStore,
-  log: (line: string) => void
+  log: (line: string) => void,
+  requireAtLeastOnePass = true
 ): Promise<{ summary: GateRunSummary; exitCode: number }> {
   const summary: GateRunSummary = { passed: [], quarantined: [], blocked: [] };
   let exitCode = 0;
@@ -515,7 +521,7 @@ export async function runApplyGateLoop(
     log('');
   }
 
-  if (summary.passed.length === 0) {
+  if (requireAtLeastOnePass && summary.passed.length === 0) {
     exitCode = 1;
     log(`GATE FAILED: no schema passed; refusing to treat a systemic failure as ${summary.quarantined.length} quarantines.`);
   }
@@ -739,7 +745,15 @@ async function runCli(argv: string[]): Promise<number> {
   const sources = loadMigrationSources();
 
   const discovery = await createSchemaCliConnection(settings, { multipleStatements: false });
-  const catalog = await createSchemaCliConnection(settings, { database: CATALOG_DATABASE_NAME, multipleStatements: false });
+  // Guarded: a failure opening the catalog connection must not strand the
+  // discovery connection, which has no finally block covering it yet.
+  let catalog: Awaited<ReturnType<typeof createSchemaCliConnection>>;
+  try {
+    catalog = await createSchemaCliConnection(settings, { database: CATALOG_DATABASE_NAME, multipleStatements: false });
+  } catch (error) {
+    await discovery.end();
+    throw error;
+  }
   const gateExec = executorFor(catalog);
 
   try {
@@ -772,7 +786,8 @@ async function runCli(argv: string[]): Promise<number> {
         return { schema, passed: outcome.passed, reason: outcome.reason };
       },
       store,
-      line => console.log(line)
+      line => console.log(line),
+      args.allSites
     );
     writeGateResultFile(summary);
     reportGateRunToCi(summary);

--- a/frontend/scripts/apply-schema-migrations.ts
+++ b/frontend/scripts/apply-schema-migrations.ts
@@ -41,6 +41,19 @@ import {
   type SchemaDifference
 } from '@/lib/db/schema-contract';
 import { SCHEMA_MIGRATION_MANIFEST, type MigrationManifestEntry } from '../db/migrations/manifest';
+import { CATALOG_DATABASE_NAME } from '../db/migrations/catalog-manifest';
+import {
+  SchemaGateUnavailableError,
+  currentRunRef,
+  pruneGateRows,
+  readQuarantinedSchemas,
+  readSchemaGateRows,
+  recordGateBlock,
+  recordGatePass,
+  recordGateQuarantine,
+  type EnvVars,
+  type SchemaGateRow
+} from './lib/schema-gate';
 import {
   SITE_SCHEMA_LIKE,
   assertExpectedHost,
@@ -85,7 +98,7 @@ export const REQUIRED_INGESTION_PROCEDURES = ['bulkingestionprocess'] as const;
 export const EXEMPT_TEXT_COLLATION_COLUMNS = new Set<string>();
 
 /** ErrorSummary is TEXT; keep recorded failure summaries bounded. */
-const ERROR_SUMMARY_MAX_LENGTH = 2000;
+export const ERROR_SUMMARY_MAX_LENGTH = 2000;
 
 const CLI_FLAG = {
   CHECK: '--check',
@@ -400,6 +413,166 @@ export function contractGateFailed(audit: ContractAudit): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Quarantine (see #429): a schema that has never passed the gate must not take
+// every other schema's deploy down with it; a schema that HAS passed and now
+// fails is a regression this deploy introduced and still blocks.
+// ---------------------------------------------------------------------------
+
+export type GateOutcome = 'passed' | 'quarantined' | 'blocked';
+
+export const GATE_RESULT_PATH_ENV = 'SCHEMA_GATE_RESULT_PATH';
+const GITHUB_ACTIONS_ENV = 'GITHUB_ACTIONS';
+const GITHUB_STEP_SUMMARY_ENV = 'GITHUB_STEP_SUMMARY';
+const GATE_LOG_PREFIX = '  GATE   ';
+const ANNOTATION_TITLE = 'Schema quarantined';
+
+export interface SchemaGateResult {
+  schema: string;
+  passed: boolean;
+  /** Empty when passed; otherwise the audit/migration lines that failed. */
+  reason: string;
+}
+
+export interface GateRunSummary {
+  passed: string[];
+  quarantined: Array<{ schema: string; reason: string; since: string }>;
+  blocked: Array<{ schema: string; reason: string }>;
+}
+
+/** Injectable gate-table access so the loop is unit-testable without MySQL. */
+export interface GateStore {
+  rows: Map<string, SchemaGateRow>;
+  pass(schema: string): Promise<void>;
+  /** Returns the effective QuarantinedAt (the original one on a re-run). */
+  quarantine(schema: string, reason: string): Promise<Date>;
+  block(schema: string): Promise<void>;
+}
+
+export function decideGateOutcome(schemaPassed: boolean, priorRow: SchemaGateRow | null): GateOutcome {
+  if (schemaPassed) return 'passed';
+  return priorRow?.lastPassedAt == null ? 'quarantined' : 'blocked';
+}
+
+/** The lines printAudit would show, joined for storage; migration failure first when present. */
+export function formatGateReason(audit: ContractAudit | null, migrationFailure: { id: string; error: string } | null): string {
+  const lines: string[] = [];
+  if (migrationFailure) lines.push(`MIGRATION FAILED ${migrationFailure.id}: ${migrationFailure.error}`);
+  if (audit) {
+    for (const failure of audit.contractFailures) {
+      lines.push(
+        `DRIFT [${failure.table}] ${failure.category} "${failure.object}" ${failure.kind}: expected=${JSON.stringify(failure.expected)} actual=${JSON.stringify(failure.actual)}`
+      );
+    }
+    for (const proc of audit.missingProcedures) lines.push(`MISSING PROCEDURE ${proc}`);
+    for (const id of audit.pendingMigrationIds) lines.push(`PENDING MIGRATION ${id}`);
+  }
+  return lines.join('\n').slice(0, ERROR_SUMMARY_MAX_LENGTH);
+}
+
+/**
+ * Applies the per-schema outcome rule across every discovered schema. A
+ * quarantined schema never stops the loop; a blocked schema stops it (today's
+ * "abort remaining schemas" behavior) and fails the run; zero passing schemas
+ * fails the run regardless, so a bad migration cannot ship as N quarantines.
+ */
+export async function runApplyGateLoop(
+  schemas: string[],
+  processOne: (schema: string) => Promise<SchemaGateResult>,
+  store: GateStore,
+  log: (line: string) => void
+): Promise<{ summary: GateRunSummary; exitCode: number }> {
+  const summary: GateRunSummary = { passed: [], quarantined: [], blocked: [] };
+  let exitCode = 0;
+
+  for (const schema of schemas) {
+    log(`Schema: ${schema}`);
+    let result: SchemaGateResult;
+    try {
+      result = await processOne(schema);
+    } catch (error) {
+      result = { schema, passed: false, reason: errorMessage(error).slice(0, ERROR_SUMMARY_MAX_LENGTH) };
+      log(`  SCHEMA FAILED  ${schema}: ${result.reason}`);
+    }
+
+    const outcome = decideGateOutcome(result.passed, store.rows.get(schema.toLowerCase()) ?? null);
+    if (outcome === 'passed') {
+      await store.pass(schema);
+      summary.passed.push(schema);
+      log(`${GATE_LOG_PREFIX}passed`);
+    } else if (outcome === 'quarantined') {
+      const since = await store.quarantine(schema, result.reason);
+      summary.quarantined.push({ schema, reason: result.reason, since: since.toISOString() });
+      log(`${GATE_LOG_PREFIX}quarantined (never passed; first quarantined ${since.toISOString()})`);
+    } else {
+      await store.block(schema);
+      summary.blocked.push({ schema, reason: result.reason });
+      exitCode = 1;
+      log(`${GATE_LOG_PREFIX}BLOCKED (passed before; this deploy regressed it)`);
+      log(`  ABORTING remaining schemas after apply failure to limit partial rollout.`);
+      log('');
+      break;
+    }
+    log('');
+  }
+
+  if (summary.passed.length === 0) {
+    exitCode = 1;
+    log(`GATE FAILED: no schema passed; refusing to treat a systemic failure as ${summary.quarantined.length} quarantines.`);
+  }
+
+  const quarantinedNames = summary.quarantined.map(entry => entry.schema).join(', ');
+  log(
+    `Gate summary: ${summary.passed.length} passed, ${summary.quarantined.length} quarantined${quarantinedNames ? ` (${quarantinedNames})` : ''}, ${summary.blocked.length} blocked`
+  );
+  return { summary, exitCode };
+}
+
+export function formatGitHubAnnotations(summary: GateRunSummary): string[] {
+  return summary.quarantined.map(entry => `::warning title=${ANNOTATION_TITLE}::${entry.schema} — ${entry.reason.split('\n')[0]}`);
+}
+
+function formatStepSummaryMarkdown(summary: GateRunSummary): string {
+  const rows = [
+    ...summary.passed.map(schema => `| ${schema} | passed | | |`),
+    ...summary.quarantined.map(entry => `| ${entry.schema} | quarantined | ${entry.reason.split('\n')[0]} | ${entry.since} |`),
+    ...summary.blocked.map(entry => `| ${entry.schema} | BLOCKED | ${entry.reason.split('\n')[0]} | |`)
+  ];
+  return ['## Schema contract gate', '', '| Schema | Outcome | Reason | Quarantined since |', '|---|---|---|---|', ...rows, ''].join('\n');
+}
+
+/** Writes the JSON the workflow's "Report quarantined schemas" step reads. No-op unless the env var is set. */
+export function writeGateResultFile(summary: GateRunSummary, env: EnvVars = process.env): void {
+  const target = env[GATE_RESULT_PATH_ENV];
+  if (!target) return;
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, JSON.stringify(summary, null, 2), 'utf-8');
+}
+
+function reportGateRunToCi(summary: GateRunSummary, env: EnvVars = process.env): void {
+  if (env[GITHUB_ACTIONS_ENV] !== 'true') return;
+  for (const line of formatGitHubAnnotations(summary)) console.log(line);
+  const stepSummaryPath = env[GITHUB_STEP_SUMMARY_ENV];
+  if (stepSummaryPath) fs.appendFileSync(stepSummaryPath, formatStepSummaryMarkdown(summary), 'utf-8');
+}
+
+function gateStoreFor(exec: SqlExecutor, rows: Map<string, SchemaGateRow>, runRef: string): GateStore {
+  return {
+    rows,
+    async pass(schema) {
+      await recordGatePass(exec, schema, runRef);
+    },
+    async quarantine(schema, reason) {
+      await recordGateQuarantine(exec, schema, reason, runRef);
+      const after = await readSchemaGateRows(exec);
+      return after.get(schema.toLowerCase())?.quarantinedAt ?? new Date();
+    },
+    async block(schema) {
+      await recordGateBlock(exec, schema, runRef);
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
 // CLI
 // ---------------------------------------------------------------------------
 
@@ -473,12 +646,18 @@ function printAudit(audit: ContractAudit): void {
   }
 }
 
+interface ProcessSchemaOutcome {
+  passed: boolean;
+  reason: string;
+  audit: ContractAudit | null;
+}
+
 async function processSchema(
   settings: ReturnType<typeof resolveConnectionSettings>,
   schema: string,
   mode: RunnerMode,
   sources: MigrationSource[]
-): Promise<boolean> {
+): Promise<ProcessSchemaOutcome> {
   let schemaConnection: Awaited<ReturnType<typeof createSchemaCliConnection>> | null = null;
   try {
     schemaConnection = await createSchemaCliConnection(settings, { database: schema, multipleStatements: true });
@@ -489,11 +668,12 @@ async function processSchema(
       console.log(`  applied: ${result.appliedNow.length === 0 ? '(none pending)' : result.appliedNow.join(', ')}`);
       if (result.failed) {
         console.error(`  MIGRATION FAILED  ${result.failed.id}: ${result.failed.error}`);
-        return false;
+        return { passed: false, reason: formatGateReason(null, result.failed), audit: null };
       }
       const audit = await auditSchemaContract(exec, schema, []);
       printAudit(audit);
-      return !contractGateFailed(audit);
+      const passed = !contractGateFailed(audit);
+      return { passed, reason: passed ? '' : formatGateReason(audit, null), audit };
     }
 
     const ledger = await readLedger(exec, schema);
@@ -505,10 +685,50 @@ async function processSchema(
       pending.map(p => p.id)
     );
     printAudit(audit);
-    return !contractGateFailed(audit);
+    const passed = !contractGateFailed(audit);
+    return { passed, reason: passed ? '' : formatGateReason(audit, null), audit };
   } finally {
     if (schemaConnection) await schemaConnection.end();
   }
+}
+
+function printQuarantined(schema: string, row: SchemaGateRow): void {
+  console.log(`Schema: ${schema}  [QUARANTINED since ${row.quarantinedAt?.toISOString() ?? 'unknown'}]`);
+  for (const line of (row.quarantineReason ?? '').split('\n').filter(Boolean)) console.log(`  ${line}`);
+  console.log();
+}
+
+async function runCheckLoop(
+  settings: ReturnType<typeof resolveConnectionSettings>,
+  schemas: string[],
+  sources: MigrationSource[],
+  quarantined: Map<string, SchemaGateRow>
+): Promise<number> {
+  let exitCode = 0;
+  let checked = 0;
+  for (const schema of schemas) {
+    const row = quarantined.get(schema.toLowerCase());
+    if (row) {
+      printQuarantined(schema, row);
+      continue;
+    }
+    console.log(`Schema: ${schema}`);
+    try {
+      const outcome = await processSchema(settings, schema, 'check', sources);
+      checked++;
+      if (!outcome.passed) exitCode = 1;
+    } catch (error) {
+      console.error(`  SCHEMA FAILED  ${schema}: ${errorMessage(error)}`);
+      exitCode = 1;
+    }
+    console.log();
+  }
+  if (checked === 0) {
+    console.error(`GATE FAILED: every discovered schema is quarantined; nothing was checked.`);
+    exitCode = 1;
+  }
+  console.log(`Check summary: ${checked} checked, ${quarantined.size} quarantined`);
+  return exitCode;
 }
 
 async function runCli(argv: string[]): Promise<number> {
@@ -519,8 +739,9 @@ async function runCli(argv: string[]): Promise<number> {
   const sources = loadMigrationSources();
 
   const discovery = await createSchemaCliConnection(settings, { multipleStatements: false });
+  const catalog = await createSchemaCliConnection(settings, { database: CATALOG_DATABASE_NAME, multipleStatements: false });
+  const gateExec = executorFor(catalog);
 
-  let exitCode = 0;
   try {
     const schemas = args.allSites ? await discoverSiteSchemas(discovery) : [args.schema as string];
     if (args.allSites) {
@@ -530,35 +751,39 @@ async function runCli(argv: string[]): Promise<number> {
     console.log(`Mode: ${args.mode.toUpperCase()} | Target: ${args.allSites ? 'all sites' : args.schema} | Host: ${settings.host}`);
     console.log(`Discovered ${schemas.length} schema(s). Manifest migrations: ${sources.map(s => s.id).join(', ')}\n`);
 
-    for (const schema of schemas) {
-      console.log(`Schema: ${schema}`);
-      try {
-        // A per-schema connection or processing failure fails the run (exitCode=1)
-        // but must not abort the remaining schemas — mirrors deploy-validations.
-        const passed = await processSchema(settings, schema, args.mode, sources);
-        if (!passed) {
-          exitCode = 1;
-          if (args.mode === 'apply') {
-            console.error(`  ABORTING remaining schemas after apply failure to limit partial rollout.`);
-            break;
-          }
-        }
-      } catch (error) {
-        console.error(`  SCHEMA FAILED  ${schema}: ${errorMessage(error)}`);
-        exitCode = 1;
-        if (args.mode === 'apply') {
-          console.error(`  ABORTING remaining schemas after apply failure to limit partial rollout.`);
-          break;
-        }
-      }
-      console.log();
+    if (args.mode === 'check') {
+      const quarantined = await readQuarantinedSchemas(gateExec);
+      return await runCheckLoop(settings, schemas, sources, quarantined);
     }
+
+    // Gate-table failures are infrastructure, not schema state: they abort the run
+    // here, before any schema is touched, and never produce a quarantine row.
+    const gateRows = await readSchemaGateRows(gateExec);
+    if (args.allSites) {
+      const pruned = await pruneGateRows(gateExec, schemas);
+      for (const name of pruned) console.log(`Pruned gate row for missing schema: ${name}`);
+    }
+
+    const store = gateStoreFor(gateExec, gateRows, currentRunRef());
+    const { summary, exitCode } = await runApplyGateLoop(
+      schemas,
+      async schema => {
+        const outcome = await processSchema(settings, schema, 'apply', sources);
+        return { schema, passed: outcome.passed, reason: outcome.reason };
+      },
+      store,
+      line => console.log(line)
+    );
+    writeGateResultFile(summary);
+    reportGateRunToCi(summary);
+    return exitCode;
   } finally {
+    await catalog.end();
     await discovery.end();
   }
-
-  return exitCode;
 }
+
+export { runCli };
 
 const invokedDirectly = (() => {
   if (!process.argv[1]) return false;
@@ -578,7 +803,8 @@ if (invokedDirectly) {
       process.exitCode = code;
     })
     .catch((error: unknown) => {
-      console.error(`\nFatal: ${errorMessage(error)}`);
+      const prefix = error instanceof SchemaGateUnavailableError ? 'Gate unavailable' : 'Fatal';
+      console.error(`\n${prefix}: ${errorMessage(error)}`);
       process.exitCode = 1;
     });
 }

--- a/frontend/scripts/check-schema-contract.test.ts
+++ b/frontend/scripts/check-schema-contract.test.ts
@@ -39,6 +39,26 @@ describe('summarizeAudits', () => {
     expect(summary.checked).toBe(0);
     expect(summary.message).toBe('schema-contract FAILED: 0 schemas checked, 0 incompatible');
   });
+  it('reports quarantined schemas in the OK line without counting them as checked', () => {
+    const summary = summarizeAudits([audit('a', true), audit('b', true)], ['forestgeo_new']);
+    console.log(`[summary] ${JSON.stringify(summary)}`);
+    expect(summary.passed).toBe(true);
+    expect(summary.checked).toBe(2);
+    expect(summary.quarantined).toBe(1);
+    expect(summary.message).toBe('schema-contract OK: 2 schemas (1 quarantined: forestgeo_new)');
+  });
+
+  it('still fails when every schema is quarantined (zero checked)', () => {
+    const summary = summarizeAudits([], ['forestgeo_a', 'forestgeo_b']);
+    console.log(`[summary] ${JSON.stringify(summary)}`);
+    expect(summary.passed).toBe(false);
+    expect(summary.message).toBe('schema-contract FAILED: 0 schemas checked, 0 incompatible (2 quarantined: forestgeo_a, forestgeo_b)');
+  });
+
+  it('keeps the exact legacy message when nothing is quarantined', () => {
+    expect(summarizeAudits([audit('a', true)]).message).toBe('schema-contract OK: 1 schemas');
+    expect(summarizeAudits([audit('a', true)]).quarantined).toBe(0);
+  });
 });
 
 describe('parseAuditArgs', () => {

--- a/frontend/scripts/check-schema-contract.ts
+++ b/frontend/scripts/check-schema-contract.ts
@@ -10,7 +10,10 @@
  * It ends in exactly one of:
  *   schema-contract OK: N schemas
  *   schema-contract FAILED: N schemas checked, M incompatible
- * N = 0 is ALWAYS a failure (a discovery failure must never read as a green run).
+ * each with a " (Q quarantined: ...)" suffix when the deploy gate has quarantined
+ * schemas (see #429) — those are printed with their stored reason and never
+ * audited here. N = 0 is ALWAYS a failure (a discovery failure, or an all-
+ * quarantined server, must never read as a green run).
  *
  * Flags:
  *   --schema <name>   audit ONE schema using LOCAL test credentials
@@ -33,6 +36,8 @@ import {
   type MigrationSource
 } from './apply-schema-migrations';
 import { assertExpectedHost, createSchemaCliConnection, discoverSiteSchemas, executorFor, resolveConnectionSettings } from './lib/schema-cli';
+import { CATALOG_DATABASE_NAME } from '../db/migrations/catalog-manifest';
+import { readQuarantinedSchemas, type SchemaGateRow } from './lib/schema-gate';
 
 const CLI_FLAG = {
   SCHEMA: '--schema',
@@ -76,20 +81,26 @@ export function parseAuditArgs(argv: string[]): AuditArgs {
 export interface AuditSummary {
   checked: number;
   incompatible: number;
+  quarantined: number;
   passed: boolean;
   message: string;
 }
 
 /**
  * Decides the overall pass/fail from per-schema audits. N = 0 is ALWAYS a
- * failure: a run that checked zero schemas must never report success.
+ * failure: a run that checked zero schemas must never report success, and a
+ * quarantined schema is not a checked schema.
  */
-export function summarizeAudits(audits: ContractAudit[]): AuditSummary {
+export function summarizeAudits(audits: ContractAudit[], quarantinedSchemas: readonly string[] = []): AuditSummary {
   const checked = audits.length;
   const incompatible = audits.filter(audit => !audit.ok).length;
+  const quarantined = quarantinedSchemas.length;
   const passed = checked > 0 && incompatible === 0;
-  const message = passed ? `schema-contract OK: ${checked} schemas` : `schema-contract FAILED: ${checked} schemas checked, ${incompatible} incompatible`;
-  return { checked, incompatible, passed, message };
+  const quarantineSuffix = quarantined === 0 ? '' : ` (${quarantined} quarantined: ${quarantinedSchemas.join(', ')})`;
+  const message = passed
+    ? `schema-contract OK: ${checked} schemas${quarantineSuffix}`
+    : `schema-contract FAILED: ${checked} schemas checked, ${incompatible} incompatible${quarantineSuffix}`;
+  return { checked, incompatible, quarantined, passed, message };
 }
 
 function printAuditDetail(audit: ContractAudit): void {
@@ -111,6 +122,11 @@ function printAuditDetail(audit: ContractAudit): void {
   for (const id of audit.pendingMigrationIds) {
     console.log(`  PENDING MIGRATION  ${id}`);
   }
+}
+
+function printQuarantinedDetail(schema: string, row: SchemaGateRow): void {
+  console.log(`Schema: ${schema}  [QUARANTINED since ${row.quarantinedAt?.toISOString() ?? 'unknown'}]`);
+  for (const line of (row.quarantineReason ?? '').split('\n').filter(Boolean)) console.log(`  ${line}`);
 }
 
 async function auditOneSchema(settings: ReturnType<typeof resolveConnectionSettings>, schema: string, sources: MigrationSource[]): Promise<ContractAudit> {
@@ -140,24 +156,34 @@ async function runCli(argv: string[]): Promise<number> {
   const sources = loadMigrationSources();
 
   const discovery = await createSchemaCliConnection(settings, { multipleStatements: false });
+  const catalog = await createSchemaCliConnection(settings, { database: CATALOG_DATABASE_NAME, multipleStatements: false });
 
   const audits: ContractAudit[] = [];
+  const quarantinedNames: string[] = [];
   try {
     const schemas = args.allSites ? await discoverSiteSchemas(discovery) : [args.schema as string];
     if (args.allSites) {
       assertSiteSchemasDiscovered(schemas);
     }
+    const quarantined = await readQuarantinedSchemas(executorFor(catalog));
 
     for (const schema of schemas) {
+      const row = quarantined.get(schema.toLowerCase());
+      if (row) {
+        printQuarantinedDetail(schema, row);
+        quarantinedNames.push(schema);
+        continue;
+      }
       const audit = await auditOneSchema(settings, schema, sources);
       audits.push(audit);
       printAuditDetail(audit);
     }
   } finally {
+    await catalog.end();
     await discovery.end();
   }
 
-  const summary = summarizeAudits(audits);
+  const summary = summarizeAudits(audits, quarantinedNames);
   console.log(`\n${summary.message}`);
   return summary.passed ? 0 : 1;
 }

--- a/frontend/scripts/check-schema-contract.ts
+++ b/frontend/scripts/check-schema-contract.ts
@@ -156,7 +156,15 @@ async function runCli(argv: string[]): Promise<number> {
   const sources = loadMigrationSources();
 
   const discovery = await createSchemaCliConnection(settings, { multipleStatements: false });
-  const catalog = await createSchemaCliConnection(settings, { database: CATALOG_DATABASE_NAME, multipleStatements: false });
+  // Guarded: a failure opening the catalog connection must not strand the
+  // discovery connection, which has no finally block covering it yet.
+  let catalog: Awaited<ReturnType<typeof createSchemaCliConnection>>;
+  try {
+    catalog = await createSchemaCliConnection(settings, { database: CATALOG_DATABASE_NAME, multipleStatements: false });
+  } catch (error) {
+    await discovery.end();
+    throw error;
+  }
 
   const audits: ContractAudit[] = [];
   const quarantinedNames: string[] = [];

--- a/frontend/scripts/deploy-taxonomy-views-to-all-schemas.test.ts
+++ b/frontend/scripts/deploy-taxonomy-views-to-all-schemas.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Connection } from 'mysql2/promise';
-import { deployTaxonomyViewsToSchema, extractViewStatements } from './deploy-taxonomy-views-to-all-schemas';
+import { deployTaxonomyViewsToSchema, extractViewStatements, quarantineSkipDetail } from './deploy-taxonomy-views-to-all-schemas';
 
 describe('taxonomy view deployment helpers', () => {
   it('extracts only the two allowlisted view statements', () => {
@@ -32,5 +32,20 @@ describe('taxonomy view deployment helpers', () => {
 
     expect(query.mock.calls.map(([sql]) => sql)).toEqual([...statements.values()]);
     expect(onApplied.mock.calls.map(([name]) => name)).toEqual([...statements.keys()]);
+  });
+});
+
+describe('quarantineSkipDetail', () => {
+  it('names the gate, the time, and the first reason line', () => {
+    const detail = quarantineSkipDetail({
+      schemaName: 'forestgeo_new',
+      lastPassedAt: null,
+      lastFailedAt: null,
+      quarantinedAt: new Date('2026-09-02T18:04:11Z'),
+      quarantineReason: 'DRIFT one\nDRIFT two',
+      lastRunRef: null
+    });
+    console.log(`[taxonomy skip detail] ${detail}`);
+    expect(detail).toBe('Quarantined by the schema contract gate since 2026-09-02T18:04:11.000Z: DRIFT one');
   });
 });

--- a/frontend/scripts/deploy-taxonomy-views-to-all-schemas.ts
+++ b/frontend/scripts/deploy-taxonomy-views-to-all-schemas.ts
@@ -23,7 +23,10 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import type { Connection, RowDataPacket } from 'mysql2/promise';
-import { assertExpectedHost, createSchemaCliConnection, discoverSiteSchemas, resolveConnectionSettings } from './lib/schema-cli';
+import { assertExpectedHost, createSchemaCliConnection, discoverSiteSchemas, executorFor, resolveConnectionSettings } from './lib/schema-cli';
+import { quarantineSkipDetail, readQuarantinedSchemas } from './lib/schema-gate';
+
+export { quarantineSkipDetail };
 
 const TAXONOMY_VIEWS = ['alltaxonomiesview', 'stemtaxonomiesview'] as const;
 const REQUIRED_BASE_TABLES = ['species', 'genus', 'family', 'trees', 'stems'] as const;
@@ -111,6 +114,10 @@ export async function deployTaxonomyViewsToAllSchemas(): Promise<void> {
     }
 
     console.log(`Found ${schemas.length} ForestGEO schemas.\n`);
+
+    // Read once on the discovery connection: a quarantined schema is one the
+    // contract gate could not verify, so it must not receive new view DDL.
+    const quarantined = await readQuarantinedSchemas(executorFor(discoveryConnection));
     console.log('[Step 2] Applying views to each schema that has base taxonomy tables...\n');
 
     const results: SchemaResult[] = [];
@@ -119,6 +126,15 @@ export async function deployTaxonomyViewsToAllSchemas(): Promise<void> {
       console.log(`Processing: ${schema}`);
 
       try {
+        const quarantineRow = quarantined.get(schema.toLowerCase());
+        if (quarantineRow) {
+          const detail = quarantineSkipDetail(quarantineRow);
+          console.log(`  SKIPPED - ${detail}`);
+          results.push({ schema, status: 'skipped', detail });
+          console.log();
+          continue;
+        }
+
         const { ready, missing } = await hasRequiredBaseTables(discoveryConnection, schema);
         if (!ready) {
           const detail = `Missing base tables: ${missing.join(', ')}. Not a provisioned site schema — skipped.`;
@@ -156,7 +172,7 @@ export async function deployTaxonomyViewsToAllSchemas(): Promise<void> {
 
     console.log(`Total schemas:  ${schemas.length}`);
     console.log(`Deployed:       ${deployed.length}`);
-    console.log(`Skipped:        ${skipped.length} (no base taxonomy tables)`);
+    console.log(`Skipped:        ${skipped.length} (no base taxonomy tables, or quarantined)`);
     console.log(`Failed:         ${failed.length}`);
     console.log();
 

--- a/frontend/scripts/deploy-validations-to-all-schemas.test.ts
+++ b/frontend/scripts/deploy-validations-to-all-schemas.test.ts
@@ -28,6 +28,7 @@ function makeCliDeps(overrides: Partial<DeployCliDeps> = {}): DeployCliDeps {
     createConnection: vi.fn().mockResolvedValue(makeConnection()),
     discoverSchemas: vi.fn().mockResolvedValue([]),
     checkMigrationStatus: vi.fn().mockResolvedValue({ migrated: true, missingTables: [] }),
+    readQuarantinedSchemas: vi.fn().mockResolvedValue(new Map()),
     log: vi.fn(),
     ...overrides
   };
@@ -146,6 +147,33 @@ describe('main CLI dispatch', () => {
 
     await expect(main(['--activate-validation-19'], deps)).rejects.toThrow('schema discovery failed');
     expect(deps.log).toHaveBeenCalledWith('Discovery connection cleanup failed after schema discovery failed: discovery close failed');
+  });
+  it('skips a quarantined schema in every mode and never opens a connection to it', async () => {
+    const quarantinedRow = {
+      schemaName: 'forestgeo_new',
+      lastPassedAt: null,
+      lastFailedAt: new Date('2026-09-02T18:04:11Z'),
+      quarantinedAt: new Date('2026-09-02T18:04:11Z'),
+      quarantineReason: 'DRIFT [stems] column "PublishedStemID" missing',
+      lastRunRef: 'run'
+    };
+
+    for (const args of [[], ['--procedures-only'], ['--activate-validation-19']]) {
+      const discoveryConn = makeConnection();
+      const deps = makeCliDeps({
+        discoverSchemas: vi.fn().mockResolvedValue(['forestgeo_new']),
+        readQuarantinedSchemas: vi.fn().mockResolvedValue(new Map([['forestgeo_new', quarantinedRow]])),
+        createConnection: vi.fn().mockResolvedValue(discoveryConn)
+      });
+
+      await main(args, deps);
+
+      const logLines = (deps.log as ReturnType<typeof vi.fn>).mock.calls.map(([line]) => String(line ?? ''));
+      console.log(`[quarantine skip ${JSON.stringify(args)}] ${logLines.filter(line => /Quarantined/.test(line)).join(' | ')}`);
+      expect(logLines.some(line => line.includes('SKIPPED (quarantined) - Quarantined by the schema contract gate since 2026-09-02T18:04:11.000Z'))).toBe(true);
+      expect(deps.createConnection, 'only the discovery connection may be opened').toHaveBeenCalledTimes(1);
+      expect(deps.readQuarantinedSchemas).toHaveBeenCalledTimes(1);
+    }
   });
 });
 

--- a/frontend/scripts/deploy-validations-to-all-schemas.ts
+++ b/frontend/scripts/deploy-validations-to-all-schemas.ts
@@ -40,6 +40,8 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { validateSchemaOrThrow } from '@/lib/db/sqlsecurity';
 import { REQUIRED_PROCEDURES } from '@/lib/provisioning/steps/sql-steps';
+import { executorFor } from './lib/schema-cli';
+import { quarantineSkipDetail, readQuarantinedSchemas, type SchemaGateRow } from './lib/schema-gate';
 
 export const AZURE_HOST = 'forestgeo-mysqldataserver.mysql.database.azure.com';
 export const AZURE_USER = 'azureroot';
@@ -292,6 +294,7 @@ export interface DeployCliDeps {
   createConnection: (options: mysql.ConnectionOptions) => Promise<mysql.Connection>;
   discoverSchemas: (conn: mysql.Connection) => Promise<string[]>;
   checkMigrationStatus: (conn: mysql.Connection, schema: string) => Promise<{ migrated: boolean; missingTables: string[] }>;
+  readQuarantinedSchemas: (conn: mysql.Connection) => Promise<Map<string, SchemaGateRow>>;
   log: (message?: string) => void;
 }
 
@@ -317,6 +320,7 @@ export const realDeps: DeployCliDeps = {
   createConnection: options => mysql.createConnection(options),
   discoverSchemas: discoverForestGeoSchemas,
   checkMigrationStatus,
+  readQuarantinedSchemas: conn => readQuarantinedSchemas(executorFor(conn)),
   log: (message = '') => console.log(message)
 };
 
@@ -408,6 +412,10 @@ async function runForAllSchemas<TPrepared = undefined>(deps: DeployCliDeps, pass
     if (options.listSchemas) schemas.forEach(schema => deps.log(`  - ${schema}`));
     deps.log('');
 
+    // Read once on the discovery connection: a quarantined schema must not get
+    // procedures it may be structurally unable to run (the #399 failure shape).
+    const quarantined = await deps.readQuarantinedSchemas(discoveryConnection);
+
     const prepared = options.prepare ? await options.prepare() : (undefined as TPrepared);
     deps.log(options.operationMessage);
     const results: SchemaResult[] = [];
@@ -415,6 +423,15 @@ async function runForAllSchemas<TPrepared = undefined>(deps: DeployCliDeps, pass
     for (const schema of schemas) {
       deps.log(`Processing: ${schema}`);
       try {
+        const quarantineRow = quarantined.get(schema.toLowerCase());
+        if (quarantineRow) {
+          const detail = quarantineSkipDetail(quarantineRow);
+          deps.log(`  SKIPPED (quarantined) - ${detail}`);
+          results.push({ schema, status: 'skipped', detail });
+          deps.log('');
+          continue;
+        }
+
         if (options.requireMigrated) {
           const { migrated, missingTables } = await deps.checkMigrationStatus(discoveryConnection, schema);
           if (!migrated) {

--- a/frontend/scripts/lib/schema-gate.test.ts
+++ b/frontend/scripts/lib/schema-gate.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import os from 'os';
+import {
+  SCHEMA_GATE_TABLE,
+  SchemaGateUnavailableError,
+  currentRunRef,
+  pruneGateRows,
+  readQuarantinedSchemas,
+  readSchemaGateRows,
+  recordGatePass,
+  recordGateQuarantine,
+  recordGateBlock
+} from './schema-gate';
+import type { SqlExecutor } from './schema-cli';
+
+const ER_NO_SUCH_TABLE = 1146;
+const ER_ACCESS_DENIED = 1045;
+
+interface FakeRow {
+  SchemaName: string;
+  LastPassedAt: Date | null;
+  LastFailedAt: Date | null;
+  QuarantinedAt: Date | null;
+  QuarantineReason: string | null;
+  LastRunRef: string | null;
+}
+
+/** Minimal in-memory catalog: answers the exact SQL shapes schema-gate.ts issues. */
+class FakeCatalog {
+  rows = new Map<string, FakeRow>();
+  statements: string[] = [];
+  failWithErrno: number | null = null;
+
+  exec: SqlExecutor = async (sql, params = []) => {
+    this.statements.push(sql);
+    if (this.failWithErrno !== null) {
+      const error = new Error(`fake mysql error ${this.failWithErrno}`) as Error & { errno: number };
+      error.errno = this.failWithErrno;
+      throw error;
+    }
+    if (sql.startsWith('SELECT')) return [...this.rows.values()] as unknown as Awaited<ReturnType<SqlExecutor>>;
+    if (sql.startsWith('DELETE')) {
+      this.rows.delete(String(params[0]));
+      return [];
+    }
+    if (sql.startsWith('INSERT')) {
+      const schema = String(params[0]);
+      const existing = this.rows.get(schema) ?? {
+        SchemaName: schema,
+        LastPassedAt: null,
+        LastFailedAt: null,
+        QuarantinedAt: null,
+        QuarantineReason: null,
+        LastRunRef: null
+      };
+      if (sql.includes('LastPassedAt = NOW()')) {
+        this.rows.set(schema, { ...existing, LastPassedAt: new Date(), QuarantinedAt: null, QuarantineReason: null, LastRunRef: String(params[1]) });
+      } else if (sql.includes('COALESCE(QuarantinedAt, NOW())')) {
+        this.rows.set(schema, {
+          ...existing,
+          LastFailedAt: new Date(),
+          QuarantinedAt: existing.QuarantinedAt ?? new Date(),
+          QuarantineReason: String(params[1]),
+          LastRunRef: String(params[2])
+        });
+      } else {
+        this.rows.set(schema, { ...existing, LastFailedAt: new Date(), LastRunRef: String(params[1]) });
+      }
+      return [];
+    }
+    throw new Error(`FakeCatalog does not understand: ${sql}`);
+  };
+}
+
+describe('schema-gate', () => {
+  it('names the table the catalog migration creates', () => {
+    expect(SCHEMA_GATE_TABLE).toBe('schema_contract_gate');
+  });
+
+  it('reads rows keyed by lower-cased schema name', async () => {
+    const catalog = new FakeCatalog();
+    catalog.rows.set('forestgeo_Mixed', {
+      SchemaName: 'forestgeo_Mixed',
+      LastPassedAt: new Date(),
+      LastFailedAt: null,
+      QuarantinedAt: null,
+      QuarantineReason: null,
+      LastRunRef: 'r'
+    });
+
+    const rows = await readSchemaGateRows(catalog.exec);
+    console.log(`[gate read] keys=${JSON.stringify([...rows.keys()])}`);
+
+    expect([...rows.keys()]).toEqual(['forestgeo_mixed']);
+    expect(rows.get('forestgeo_mixed')?.lastPassedAt).toBeInstanceOf(Date);
+    // The stored casing is preserved so writes address the row MySQL actually has.
+    expect(rows.get('forestgeo_mixed')?.schemaName).toBe('forestgeo_Mixed');
+  });
+
+  it('maps a missing table to SchemaGateUnavailableError and lets other errors through', async () => {
+    const missing = new FakeCatalog();
+    missing.failWithErrno = ER_NO_SUCH_TABLE;
+    await expect(readSchemaGateRows(missing.exec)).rejects.toBeInstanceOf(SchemaGateUnavailableError);
+    await expect(readSchemaGateRows(missing.exec)).rejects.toThrow(/apply-catalog-migrations/);
+
+    const denied = new FakeCatalog();
+    denied.failWithErrno = ER_ACCESS_DENIED;
+    await expect(readSchemaGateRows(denied.exec)).rejects.not.toBeInstanceOf(SchemaGateUnavailableError);
+  });
+
+  it('quarantine keeps the first QuarantinedAt and pass clears it', async () => {
+    const catalog = new FakeCatalog();
+    await recordGateQuarantine(catalog.exec, 'forestgeo_new', 'DRIFT [stems] column "X" missing', 'run-1');
+    const first = catalog.rows.get('forestgeo_new')!.QuarantinedAt;
+    await new Promise(resolve => setTimeout(resolve, 5));
+    await recordGateQuarantine(catalog.exec, 'forestgeo_new', 'DRIFT again', 'run-2');
+    console.log(`[gate quarantine] first=${first?.toISOString()} after=${catalog.rows.get('forestgeo_new')!.QuarantinedAt?.toISOString()}`);
+
+    expect(catalog.rows.get('forestgeo_new')!.QuarantinedAt).toBe(first);
+    expect(catalog.rows.get('forestgeo_new')!.QuarantineReason).toBe('DRIFT again');
+
+    const quarantined = await readQuarantinedSchemas(catalog.exec);
+    expect([...quarantined.keys()]).toEqual(['forestgeo_new']);
+
+    await recordGatePass(catalog.exec, 'forestgeo_new', 'run-3');
+    const row = catalog.rows.get('forestgeo_new')!;
+    expect(row.QuarantinedAt).toBeNull();
+    expect(row.QuarantineReason).toBeNull();
+    expect(row.LastPassedAt).toBeInstanceOf(Date);
+    expect((await readQuarantinedSchemas(catalog.exec)).size).toBe(0);
+  });
+
+  it('block records a failure without touching quarantine', async () => {
+    const catalog = new FakeCatalog();
+    await recordGatePass(catalog.exec, 'forestgeo_old', 'run-1');
+    await recordGateBlock(catalog.exec, 'forestgeo_old', 'run-2');
+    const row = catalog.rows.get('forestgeo_old')!;
+    console.log(`[gate block] passedAt=${row.LastPassedAt?.toISOString()} failedAt=${row.LastFailedAt?.toISOString()} quarantinedAt=${row.QuarantinedAt}`);
+
+    expect(row.LastFailedAt).toBeInstanceOf(Date);
+    expect(row.QuarantinedAt).toBeNull();
+    expect(row.LastPassedAt).toBeInstanceOf(Date);
+  });
+
+  it('prunes only rows whose schema was not discovered', async () => {
+    const catalog = new FakeCatalog();
+    await recordGatePass(catalog.exec, 'forestgeo_keep', 'r');
+    await recordGatePass(catalog.exec, 'forestgeo_gone', 'r');
+
+    const pruned = await pruneGateRows(catalog.exec, ['forestgeo_keep']);
+    console.log(`[gate prune] pruned=${JSON.stringify(pruned)} remaining=${JSON.stringify([...catalog.rows.keys()])}`);
+
+    expect(pruned).toEqual(['forestgeo_gone']);
+    expect([...catalog.rows.keys()]).toEqual(['forestgeo_keep']);
+  });
+
+  it('matches the discovery list case-insensitively when pruning', async () => {
+    const catalog = new FakeCatalog();
+    await recordGatePass(catalog.exec, 'forestgeo_Keep', 'r');
+
+    expect(await pruneGateRows(catalog.exec, ['FORESTGEO_KEEP'])).toEqual([]);
+    expect(catalog.rows.size).toBe(1);
+  });
+
+  it('refuses to prune when discovery returned nothing', async () => {
+    const catalog = new FakeCatalog();
+    await recordGatePass(catalog.exec, 'forestgeo_keep', 'r');
+
+    expect(await pruneGateRows(catalog.exec, [])).toEqual([]);
+    expect(catalog.rows.size).toBe(1);
+  });
+
+  it('builds the run ref from Actions env, else hostname', () => {
+    expect(currentRunRef({ GITHUB_SERVER_URL: 'https://github.com', GITHUB_REPOSITORY: 'Smithsonian/ForestGEO', GITHUB_RUN_ID: '42' })).toBe(
+      'https://github.com/Smithsonian/ForestGEO/actions/runs/42'
+    );
+    expect(currentRunRef({})).toBe(`local:${os.hostname()}`);
+  });
+});

--- a/frontend/scripts/lib/schema-gate.ts
+++ b/frontend/scripts/lib/schema-gate.ts
@@ -144,3 +144,11 @@ export async function pruneGateRows(exec: SqlExecutor, discoveredSchemas: string
   }
   return pruned;
 }
+
+export const QUARANTINE_SKIP_PREFIX = 'Quarantined by the schema contract gate since';
+
+/** One-line skip reason for sweeps: gate name, time, first reason line. */
+export function quarantineSkipDetail(row: SchemaGateRow): string {
+  const firstReasonLine = (row.quarantineReason ?? '').split('\n').find(Boolean) ?? '(no reason recorded)';
+  return `${QUARANTINE_SKIP_PREFIX} ${row.quarantinedAt?.toISOString() ?? 'unknown'}: ${firstReasonLine}`;
+}

--- a/frontend/scripts/lib/schema-gate.ts
+++ b/frontend/scripts/lib/schema-gate.ts
@@ -1,0 +1,139 @@
+/**
+ * Read/write access to catalog.schema_contract_gate for the deploy CLIs.
+ *
+ * One row per site schema. The apply script writes outcomes; the read-only check
+ * and the procedure/view sweeps read them so a quarantined schema is reported and
+ * skipped, never re-failed. The app reads the same table through
+ * lib/schema-quarantine.ts. Nothing else writes it — release is earned by a
+ * passing apply run, never by hand.
+ */
+
+import os from 'os';
+import { CATALOG_DATABASE_NAME } from '../../db/migrations/catalog-manifest';
+import type { SqlExecutor } from './schema-cli';
+
+export const SCHEMA_GATE_TABLE = 'schema_contract_gate';
+
+const ER_NO_SUCH_TABLE = 1146;
+
+export interface SchemaGateRow {
+  schemaName: string;
+  lastPassedAt: Date | null;
+  lastFailedAt: Date | null;
+  quarantinedAt: Date | null;
+  quarantineReason: string | null;
+  lastRunRef: string | null;
+}
+
+export class SchemaGateUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SchemaGateUnavailableError';
+  }
+}
+
+function qualifiedGateTable(): string {
+  return `\`${CATALOG_DATABASE_NAME}\`.\`${SCHEMA_GATE_TABLE}\``;
+}
+
+function isNoSuchTableError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && (error as { errno?: unknown }).errno === ER_NO_SUCH_TABLE;
+}
+
+function toDate(value: unknown): Date | null {
+  if (value === null || value === undefined) return null;
+  return value instanceof Date ? value : new Date(String(value));
+}
+
+function toNullableString(value: unknown): string | null {
+  return value === null || value === undefined ? null : String(value);
+}
+
+function toGateRow(row: Record<string, unknown>): SchemaGateRow {
+  return {
+    schemaName: String(row.SchemaName),
+    lastPassedAt: toDate(row.LastPassedAt),
+    lastFailedAt: toDate(row.LastFailedAt),
+    quarantinedAt: toDate(row.QuarantinedAt),
+    quarantineReason: toNullableString(row.QuarantineReason),
+    lastRunRef: toNullableString(row.LastRunRef)
+  };
+}
+
+/** Actions run URL when running in CI, otherwise a hostname-tagged local marker. */
+export function currentRunRef(env: NodeJS.ProcessEnv = process.env): string {
+  const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = env;
+  if (GITHUB_SERVER_URL && GITHUB_REPOSITORY && GITHUB_RUN_ID) {
+    return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
+  }
+  return `local:${os.hostname()}`;
+}
+
+/** Every gate row, keyed by lower-cased schema name. */
+export async function readSchemaGateRows(exec: SqlExecutor): Promise<Map<string, SchemaGateRow>> {
+  let rows: Record<string, unknown>[];
+  try {
+    rows = await exec(`SELECT SchemaName, LastPassedAt, LastFailedAt, QuarantinedAt, QuarantineReason, LastRunRef FROM ${qualifiedGateTable()}`);
+  } catch (error) {
+    if (isNoSuchTableError(error)) {
+      throw new SchemaGateUnavailableError(
+        `${CATALOG_DATABASE_NAME}.${SCHEMA_GATE_TABLE} does not exist. Run "npx tsx scripts/apply-catalog-migrations.ts --apply" ` +
+          `(add --azure for the Azure server) before the schema gate.`
+      );
+    }
+    throw error;
+  }
+  return new Map(rows.map(row => [String(row.SchemaName).toLowerCase(), toGateRow(row)]));
+}
+
+/** Only the rows with QuarantinedAt set, keyed by lower-cased schema name. */
+export async function readQuarantinedSchemas(exec: SqlExecutor): Promise<Map<string, SchemaGateRow>> {
+  const all = await readSchemaGateRows(exec);
+  return new Map([...all].filter(([, row]) => row.quarantinedAt !== null));
+}
+
+export async function recordGatePass(exec: SqlExecutor, schemaName: string, runRef: string): Promise<void> {
+  await exec(
+    `INSERT INTO ${qualifiedGateTable()} (SchemaName, LastPassedAt, LastRunRef)
+     VALUES (?, NOW(), ?)
+     ON DUPLICATE KEY UPDATE LastPassedAt = NOW(), QuarantinedAt = NULL, QuarantineReason = NULL, LastRunRef = VALUES(LastRunRef)`,
+    [schemaName, runRef]
+  );
+}
+
+/** Sets QuarantinedAt only if not already set, so the first quarantine time survives re-runs. */
+export async function recordGateQuarantine(exec: SqlExecutor, schemaName: string, reason: string, runRef: string): Promise<void> {
+  await exec(
+    `INSERT INTO ${qualifiedGateTable()} (SchemaName, LastFailedAt, QuarantinedAt, QuarantineReason, LastRunRef)
+     VALUES (?, NOW(), NOW(), ?, ?)
+     ON DUPLICATE KEY UPDATE LastFailedAt = NOW(), QuarantinedAt = COALESCE(QuarantinedAt, NOW()), QuarantineReason = VALUES(QuarantineReason), LastRunRef = VALUES(LastRunRef)`,
+    [schemaName, reason, runRef]
+  );
+}
+
+/** A previously-passing schema failed: record the failure, never quarantine. */
+export async function recordGateBlock(exec: SqlExecutor, schemaName: string, runRef: string): Promise<void> {
+  await exec(
+    `INSERT INTO ${qualifiedGateTable()} (SchemaName, LastFailedAt, LastRunRef)
+     VALUES (?, NOW(), ?)
+     ON DUPLICATE KEY UPDATE LastFailedAt = NOW(), LastRunRef = VALUES(LastRunRef)`,
+    [schemaName, runRef]
+  );
+}
+
+/**
+ * Deletes rows for schemas that no longer exist (torn down). Refuses to act on an
+ * empty discovery list — that is a discovery failure, not "every site is gone".
+ */
+export async function pruneGateRows(exec: SqlExecutor, discoveredSchemas: string[]): Promise<string[]> {
+  if (discoveredSchemas.length === 0) return [];
+  const discovered = new Set(discoveredSchemas.map(schema => schema.toLowerCase()));
+  const rows = await readSchemaGateRows(exec);
+  const pruned: string[] = [];
+  for (const [key, row] of rows) {
+    if (discovered.has(key)) continue;
+    await exec(`DELETE FROM ${qualifiedGateTable()} WHERE SchemaName = ?`, [row.schemaName]);
+    pruned.push(row.schemaName);
+  }
+  return pruned;
+}

--- a/frontend/scripts/lib/schema-gate.ts
+++ b/frontend/scripts/lib/schema-gate.ts
@@ -25,6 +25,13 @@ export interface SchemaGateRow {
   lastRunRef: string | null;
 }
 
+/**
+ * Environment lookup shape for the run-ref and reporting helpers. Deliberately
+ * not the global process-env type: next/types/global.d.ts augments it with a
+ * REQUIRED NODE_ENV, so a caller could not pass a small literal env.
+ */
+export type EnvVars = Readonly<Record<string, string | undefined>>;
+
 export class SchemaGateUnavailableError extends Error {
   constructor(message: string) {
     super(message);
@@ -61,7 +68,7 @@ function toGateRow(row: Record<string, unknown>): SchemaGateRow {
 }
 
 /** Actions run URL when running in CI, otherwise a hostname-tagged local marker. */
-export function currentRunRef(env: NodeJS.ProcessEnv = process.env): string {
+export function currentRunRef(env: EnvVars = process.env): string {
   const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = env;
   if (GITHUB_SERVER_URL && GITHUB_REPOSITORY && GITHUB_RUN_ID) {
     return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;

--- a/frontend/tests/ddl-environment-neutrality.test.ts
+++ b/frontend/tests/ddl-environment-neutrality.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Every SQL file that provisioning (lib/provisioning/steps/sql-steps.ts) or the
+ * deploy pipeline (apply-schema-migrations, apply-catalog-migrations,
+ * deploy-validations, deploy-taxonomy-views) executes must not name an
+ * environment-specific account. CREATE PROCEDURE with a DEFINER that does not
+ * exist SUCCEEDS and fails only at CALL time ("The user specified as a definer
+ * ('azureroot'@'%') does not exist"), so provisioning reports success and the
+ * site breaks at first upload. See #399 and commit 807ed084.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { loadMigrationSources } from '@/scripts/apply-schema-migrations';
+import { loadCatalogMigrationSources } from '@/scripts/apply-catalog-migrations';
+import { extractViewStatements } from '@/scripts/deploy-taxonomy-views-to-all-schemas';
+
+const EXECUTED_SQL_FILES = ['db/sql/tablestructures.sql', 'db/sql/corequeries.sql', 'db/sql/storedprocedures.sql'] as const;
+const FORBIDDEN_PATTERNS: ReadonlyArray<{ label: string; pattern: RegExp }> = [
+  { label: 'explicit DEFINER clause', pattern: /\bDEFINER\s*=/i },
+  { label: 'azureroot account name', pattern: /\bazureroot\b/i }
+];
+
+interface NamedSql {
+  name: string;
+  contents: string;
+}
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf-8');
+}
+
+function violations({ name, contents }: NamedSql): string[] {
+  const found: string[] = [];
+  contents.split('\n').forEach((line, index) => {
+    for (const { label, pattern } of FORBIDDEN_PATTERNS) {
+      if (pattern.test(line)) found.push(`${name}:${index + 1} ${label}: ${line.trim()}`);
+    }
+  });
+  return found;
+}
+
+function collectExecutedSql(): NamedSql[] {
+  const files: NamedSql[] = EXECUTED_SQL_FILES.map(name => ({ name, contents: readRepoFile(name) }));
+  const siteMigrations = loadMigrationSources().map(source => ({ name: `db/migrations/${source.file}`, contents: source.contents }));
+  const catalogMigrations = loadCatalogMigrationSources().map(source => ({ name: `db/migrations/${source.file}`, contents: source.contents }));
+  const views = [...extractViewStatements(readRepoFile('db/sql/tablestructures.sql'))].map(([view, sql]) => ({
+    name: `tablestructures.sql#${view}`,
+    contents: sql
+  }));
+  return [...files, ...siteMigrations, ...catalogMigrations, ...views];
+}
+
+describe('executed DDL is environment-neutral', () => {
+  const executed = collectExecutedSql();
+
+  it('covers the three base files, every manifest migration, and both taxonomy views', () => {
+    const names = executed.map(entry => entry.name);
+    console.log(`[ddl neutrality] ${names.length} sources:\n  ${names.join('\n  ')}`);
+
+    for (const file of EXECUTED_SQL_FILES) expect(names).toContain(file);
+    expect(names.filter(name => name.startsWith('db/migrations/')).length).toBe(loadMigrationSources().length + loadCatalogMigrationSources().length);
+    expect(names).toContain('tablestructures.sql#alltaxonomiesview');
+    expect(names).toContain('tablestructures.sql#stemtaxonomiesview');
+  });
+
+  it.each(executed.map(entry => [entry.name, entry] as const))('%s names no DEFINER and no azureroot', (_name, entry) => {
+    expect(violations(entry)).toEqual([]);
+  });
+
+  it('the checker itself catches an explicit DEFINER (so a green run means something)', () => {
+    const poisoned: NamedSql = { name: 'fixture.sql', contents: "DROP PROCEDURE IF EXISTS p;\nCREATE DEFINER = azureroot@'%' PROCEDURE p() BEGIN END" };
+
+    const found = violations(poisoned);
+    console.log(`[ddl neutrality] injected-fixture violations: ${JSON.stringify(found)}`);
+
+    expect(found).toHaveLength(2);
+    expect(found[0]).toMatch(/^fixture\.sql:2 explicit DEFINER clause/);
+    expect(found[1]).toMatch(/^fixture\.sql:2 azureroot account name/);
+  });
+});

--- a/frontend/tests/integration/catalog-migration.integration.test.ts
+++ b/frontend/tests/integration/catalog-migration.integration.test.ts
@@ -23,7 +23,7 @@ import mysql, { type Connection, type RowDataPacket } from 'mysql2/promise';
 
 import {
   applyPendingCatalogMigrations,
-  CATALOG_BACKGROUND_JOB_TABLES,
+  CATALOG_OWNED_TABLES,
   CATALOG_LEDGER_TABLE,
   CATALOG_MIGRATION_LOCK_NAME,
   ensureCatalogDatabase,
@@ -51,7 +51,7 @@ const SETTINGS = {
   password: process.env.TEST_DB_PASSWORD || 'testpassword'
 };
 
-const CATALOG_MIGRATION_ID = CATALOG_MIGRATION_MANIFEST[0].id;
+const CATALOG_MIGRATION_IDS = CATALOG_MIGRATION_MANIFEST.map(entry => entry.id);
 
 describe('catalog migration gate — integration', () => {
   let connection: Connection;
@@ -73,7 +73,7 @@ describe('catalog migration gate — integration', () => {
 
   /** Full reset so each test starts from a known catalog state. */
   beforeEach(async () => {
-    for (const table of CATALOG_BACKGROUND_JOB_TABLES) {
+    for (const table of CATALOG_OWNED_TABLES) {
       await connection.query(`DROP TABLE IF EXISTS \`${CATALOG_DATABASE_NAME}\`.\`${table}\``);
     }
     await connection.query(`DROP TABLE IF EXISTS \`${CATALOG_DATABASE_NAME}\`.\`${CATALOG_LEDGER_TABLE}\``);
@@ -95,7 +95,7 @@ describe('catalog migration gate — integration', () => {
     console.log(`[apply] pendingBefore=${JSON.stringify(result.pendingBefore)} appliedNow=${JSON.stringify(result.appliedNow)}`);
 
     expect(result.failed).toBeNull();
-    expect(result.appliedNow).toEqual([CATALOG_MIGRATION_ID]);
+    expect(result.appliedNow).toEqual(CATALOG_MIGRATION_IDS);
 
     const after = await runCatalogPreflight(exec);
     console.log(`[apply] post states=${JSON.stringify(after.tables.map(entry => [entry.table, entry.state, entry.rowCount]))}`);
@@ -103,24 +103,24 @@ describe('catalog migration gate — integration', () => {
     expect(after.tables.every(entry => entry.rowCount === 0)).toBe(true);
 
     const created = await tableNames();
-    for (const table of CATALOG_BACKGROUND_JOB_TABLES) {
+    for (const table of CATALOG_OWNED_TABLES) {
       expect(created).toContain(table);
     }
 
     const ledger = await readCatalogLedger(exec);
-    expect(ledger).toHaveLength(1);
-    expect(ledger[0]).toMatchObject({ MigrationID: CATALOG_MIGRATION_ID, Status: 'applied' });
+    expect(ledger.map(row => row.MigrationID).sort()).toEqual([...CATALOG_MIGRATION_IDS].sort());
+    expect(ledger.every(row => row.Status === 'applied')).toBe(true);
   }, 60000);
 
   it('is idempotent: check → apply → check leaves no pending work and applies nothing twice', async () => {
     const sources = loadCatalogMigrationSources();
 
     // check (first): everything pending
-    expect(selectPendingCatalogMigrations(sources, await readCatalogLedger(exec)).map(source => source.id)).toEqual([CATALOG_MIGRATION_ID]);
+    expect(selectPendingCatalogMigrations(sources, await readCatalogLedger(exec)).map(source => source.id)).toEqual(CATALOG_MIGRATION_IDS);
 
     // apply
     const first = await applyPendingCatalogMigrations(exec, sources, await runCatalogPreflight(exec));
-    expect(first.appliedNow).toEqual([CATALOG_MIGRATION_ID]);
+    expect(first.appliedNow).toEqual(CATALOG_MIGRATION_IDS);
 
     // check (second): nothing pending
     expect(selectPendingCatalogMigrations(sources, await readCatalogLedger(exec))).toHaveLength(0);
@@ -129,7 +129,7 @@ describe('catalog migration gate — integration', () => {
     const second = await applyPendingCatalogMigrations(exec, sources, await runCatalogPreflight(exec));
     console.log(`[idempotency] second apply appliedNow=${JSON.stringify(second.appliedNow)}`);
     expect(second.appliedNow).toEqual([]);
-    expect(await readCatalogLedger(exec)).toHaveLength(1);
+    expect(await readCatalogLedger(exec)).toHaveLength(CATALOG_MIGRATION_IDS.length);
   }, 60000);
 
   it('holds one global catalog lock during apply and releases it afterwards', async () => {
@@ -221,10 +221,11 @@ describe('catalog migration gate — integration', () => {
 
     for (const row of siteLedgerRows) {
       const siteSchema = String(row.schemaName);
-      const [rows] = await connection.query<RowDataPacket[]>(`SELECT COUNT(*) AS count FROM \`${siteSchema}\`.\`${SITE_LEDGER_TABLE}\` WHERE MigrationID = ?`, [
-        CATALOG_MIGRATION_ID
-      ]);
-      console.log(`[separation] ${siteSchema}.${SITE_LEDGER_TABLE} rows with catalog id = ${rows[0].count}`);
+      const [rows] = await connection.query<RowDataPacket[]>(
+        `SELECT COUNT(*) AS count FROM \`${siteSchema}\`.\`${SITE_LEDGER_TABLE}\` WHERE MigrationID IN (?)`,
+        [CATALOG_MIGRATION_IDS]
+      );
+      console.log(`[separation] ${siteSchema}.${SITE_LEDGER_TABLE} rows with any catalog id = ${rows[0].count}`);
       expect(Number(rows[0].count)).toBe(0);
     }
   }, 60000);

--- a/frontend/tests/integration/schema-gate-quarantine.integration.test.ts
+++ b/frontend/tests/integration/schema-gate-quarantine.integration.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Contract-gate quarantine proof (integration, real MySQL). See #429.
+ *
+ * Two throwaway site schemas built by the same helpers every integration suite
+ * uses (tablestructures + corequeries + storedprocedures). One is regressed to a
+ * shape NO manifest migration repairs (coremeasurements.DeletedAt dropped —
+ * asserted below against the manifest sources), so the gate cannot converge it.
+ * DeletedAt is deliberately a column no index references, so restoring it
+ * restores the contract exactly and case (4) proves release, not index drift.
+ *
+ *   (1) a never-passed drifted schema is QUARANTINED, exit 0, QuarantinedAt set;
+ *   (2) a clean schema PASSES, LastPassedAt set, no quarantine;
+ *   (3) re-running the drifted schema keeps the ORIGINAL QuarantinedAt;
+ *   (4) repairing the column and re-running RELEASES it (QuarantinedAt NULL);
+ *   (5) regressing the previously-passed schema is BLOCKED: exit 1,
+ *       LastFailedAt set, QuarantinedAt still NULL;
+ *   (6) the gate refuses to run when catalog.schema_contract_gate is absent.
+ *
+ * Prerequisites: docker compose up -d mysql
+ * Run alone: npm run test:integration -- tests/integration/schema-gate-quarantine.integration.test.ts
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import mysql, { type Connection, type RowDataPacket } from 'mysql2/promise';
+import { createTestDatabase, loadSchema, loadValidationDefinitions, loadStoredProcedures, DEFAULT_TEST_CONFIG } from '../setup/local-db-setup';
+import { applyPendingCatalogMigrations, ensureCatalogDatabase, loadCatalogMigrationSources, runCatalogPreflight } from '@/scripts/apply-catalog-migrations';
+import { loadMigrationSources, runCli } from '@/scripts/apply-schema-migrations';
+import { SCHEMA_GATE_TABLE } from '@/scripts/lib/schema-gate';
+import { CATALOG_DATABASE_NAME } from '@/db/migrations/catalog-manifest';
+
+const TEST_DB_HOST = process.env.TEST_DB_HOST || 'localhost';
+if (!['localhost', '127.0.0.1', '::1'].includes(TEST_DB_HOST)) {
+  throw new Error(`[schema-gate-quarantine] Refusing to run: TEST_DB_HOST="${TEST_DB_HOST}" is not local.`);
+}
+
+const GOOD_SCHEMA = 'forestgeo_gatetest_good';
+const BAD_SCHEMA = 'forestgeo_gatetest_bad';
+const DRIFT_TABLE = 'coremeasurements';
+const DRIFT_COLUMN = 'DeletedAt';
+const DRIFT_COLUMN_DDL = 'datetime NULL';
+const EXIT_OK = 0;
+const EXIT_FAILED = 1;
+/** MySQL DATETIME has second precision, so a re-run must land in a later second. */
+const ONE_SECOND_MS = 1100;
+
+interface GateRow extends RowDataPacket {
+  SchemaName: string;
+  LastPassedAt: Date | null;
+  LastFailedAt: Date | null;
+  QuarantinedAt: Date | null;
+  QuarantineReason: string | null;
+  LastRunRef: string | null;
+}
+
+async function buildSiteSchema(database: string): Promise<void> {
+  const connection = await createTestDatabase({ ...DEFAULT_TEST_CONFIG, database });
+  try {
+    await loadSchema(connection);
+    await loadValidationDefinitions(connection);
+    await loadStoredProcedures(connection);
+  } finally {
+    await connection.end();
+  }
+}
+
+describe('schema contract gate — quarantine (integration)', () => {
+  let server: Connection;
+
+  async function gateRow(schema: string): Promise<GateRow | null> {
+    const [rows] = await server.query<GateRow[]>(`SELECT * FROM \`${CATALOG_DATABASE_NAME}\`.\`${SCHEMA_GATE_TABLE}\` WHERE SchemaName = ?`, [schema]);
+    return rows[0] ?? null;
+  }
+
+  async function dropDriftColumn(schema: string): Promise<void> {
+    await server.query(`ALTER TABLE \`${schema}\`.\`${DRIFT_TABLE}\` DROP COLUMN \`${DRIFT_COLUMN}\``);
+  }
+
+  async function restoreDriftColumn(schema: string): Promise<void> {
+    await server.query(`ALTER TABLE \`${schema}\`.\`${DRIFT_TABLE}\` ADD COLUMN \`${DRIFT_COLUMN}\` ${DRIFT_COLUMN_DDL}`);
+  }
+
+  beforeAll(async () => {
+    server = await mysql.createConnection({
+      host: DEFAULT_TEST_CONFIG.host,
+      port: DEFAULT_TEST_CONFIG.port,
+      user: DEFAULT_TEST_CONFIG.user,
+      password: DEFAULT_TEST_CONFIG.password,
+      multipleStatements: true
+    });
+
+    await ensureCatalogDatabase({ ...DEFAULT_TEST_CONFIG, allowedHosts: [TEST_DB_HOST] });
+    const catalog = await mysql.createConnection({
+      host: DEFAULT_TEST_CONFIG.host,
+      port: DEFAULT_TEST_CONFIG.port,
+      user: DEFAULT_TEST_CONFIG.user,
+      password: DEFAULT_TEST_CONFIG.password,
+      database: CATALOG_DATABASE_NAME,
+      multipleStatements: true
+    });
+    try {
+      const exec = async (sql: string, params?: unknown[]) => {
+        const [rows] = await catalog.query(sql, params ?? []);
+        return Array.isArray(rows) ? (rows as Record<string, unknown>[]) : [];
+      };
+      const result = await applyPendingCatalogMigrations(exec, loadCatalogMigrationSources(), await runCatalogPreflight(exec));
+      console.log(`[setup] catalog migrations applied now: ${JSON.stringify(result.appliedNow)} failed=${JSON.stringify(result.failed)}`);
+      expect(result.failed).toBeNull();
+      await catalog.query(`DELETE FROM \`${CATALOG_DATABASE_NAME}\`.\`${SCHEMA_GATE_TABLE}\` WHERE SchemaName IN (?, ?)`, [GOOD_SCHEMA, BAD_SCHEMA]);
+    } finally {
+      await catalog.end();
+    }
+
+    await buildSiteSchema(GOOD_SCHEMA);
+    await buildSiteSchema(BAD_SCHEMA);
+    await dropDriftColumn(BAD_SCHEMA);
+    console.log(`[setup] ${GOOD_SCHEMA} canonical; ${BAD_SCHEMA} missing ${DRIFT_TABLE}.${DRIFT_COLUMN}`);
+  }, 180000);
+
+  afterAll(async () => {
+    if (!server) return;
+    await server.query(`DROP DATABASE IF EXISTS \`${GOOD_SCHEMA}\``);
+    await server.query(`DROP DATABASE IF EXISTS \`${BAD_SCHEMA}\``);
+    await server.query(`DELETE FROM \`${CATALOG_DATABASE_NAME}\`.\`${SCHEMA_GATE_TABLE}\` WHERE SchemaName IN (?, ?)`, [GOOD_SCHEMA, BAD_SCHEMA]);
+    await server.end();
+  });
+
+  it('the induced drift is one the manifest cannot repair (guards the test against becoming a convergence test)', () => {
+    const mentioning = loadMigrationSources().filter(source => new RegExp(`\\b${DRIFT_COLUMN}\\b`, 'i').test(source.contents));
+    expect(
+      mentioning.map(source => source.id),
+      `pick a different DRIFT_COLUMN: these manifest migrations touch ${DRIFT_COLUMN}`
+    ).toEqual([]);
+  });
+
+  it('(1) quarantines a never-passed schema that fails the audit, without failing the run', async () => {
+    const exitCode = await runCli(['--schema', BAD_SCHEMA, '--apply']);
+    const row = await gateRow(BAD_SCHEMA);
+    console.log(`[case 1] exit=${exitCode} row=${JSON.stringify(row)}`);
+
+    expect(exitCode).toBe(EXIT_OK);
+    expect(row?.QuarantinedAt).toBeInstanceOf(Date);
+    expect(row?.LastPassedAt).toBeNull();
+    expect(row?.QuarantineReason).toMatch(new RegExp(`DRIFT \\[${DRIFT_TABLE}\\] column "${DRIFT_COLUMN}"`));
+  }, 120000);
+
+  it('(2) passes a clean schema and stamps LastPassedAt', async () => {
+    const exitCode = await runCli(['--schema', GOOD_SCHEMA, '--apply']);
+    const row = await gateRow(GOOD_SCHEMA);
+    console.log(`[case 2] exit=${exitCode} row=${JSON.stringify(row)}`);
+
+    expect(exitCode).toBe(EXIT_OK);
+    expect(row?.LastPassedAt).toBeInstanceOf(Date);
+    expect(row?.QuarantinedAt).toBeNull();
+  }, 120000);
+
+  it('(3) a re-run keeps the original QuarantinedAt and refreshes the reason', async () => {
+    const before = await gateRow(BAD_SCHEMA);
+    await new Promise(resolve => setTimeout(resolve, ONE_SECOND_MS));
+
+    const exitCode = await runCli(['--schema', BAD_SCHEMA, '--apply']);
+    const after = await gateRow(BAD_SCHEMA);
+    console.log(
+      `[case 3] before=${before?.QuarantinedAt?.toISOString()} after=${after?.QuarantinedAt?.toISOString()} lastFailed=${after?.LastFailedAt?.toISOString()}`
+    );
+
+    expect(exitCode).toBe(EXIT_OK);
+    expect(after?.QuarantinedAt?.getTime()).toBe(before?.QuarantinedAt?.getTime());
+    expect(after!.LastFailedAt!.getTime()).toBeGreaterThan(before!.LastFailedAt!.getTime());
+  }, 120000);
+
+  it('(4) repairing the drift and re-running releases the schema', async () => {
+    await restoreDriftColumn(BAD_SCHEMA);
+
+    const exitCode = await runCli(['--schema', BAD_SCHEMA, '--apply']);
+    const row = await gateRow(BAD_SCHEMA);
+    console.log(`[case 4] exit=${exitCode} row=${JSON.stringify(row)}`);
+
+    expect(exitCode).toBe(EXIT_OK);
+    expect(row?.QuarantinedAt).toBeNull();
+    expect(row?.QuarantineReason).toBeNull();
+    expect(row?.LastPassedAt).toBeInstanceOf(Date);
+  }, 120000);
+
+  it('(5) a previously-passed schema that regresses is BLOCKED, not quarantined', async () => {
+    await dropDriftColumn(GOOD_SCHEMA);
+
+    const exitCode = await runCli(['--schema', GOOD_SCHEMA, '--apply']);
+    const row = await gateRow(GOOD_SCHEMA);
+    console.log(`[case 5] exit=${exitCode} row=${JSON.stringify(row)}`);
+
+    expect(exitCode).toBe(EXIT_FAILED);
+    expect(row?.QuarantinedAt).toBeNull();
+    expect(row?.LastFailedAt).toBeInstanceOf(Date);
+    expect(row?.LastPassedAt).toBeInstanceOf(Date);
+
+    await restoreDriftColumn(GOOD_SCHEMA);
+  }, 120000);
+
+  it('(6) refuses to run when the gate table is absent, naming the catalog runner', async () => {
+    await server.query(`RENAME TABLE \`${CATALOG_DATABASE_NAME}\`.\`${SCHEMA_GATE_TABLE}\` TO \`${CATALOG_DATABASE_NAME}\`.\`${SCHEMA_GATE_TABLE}_hidden\``);
+    try {
+      await expect(runCli(['--schema', GOOD_SCHEMA, '--apply'])).rejects.toThrow(/apply-catalog-migrations/);
+    } finally {
+      await server.query(`RENAME TABLE \`${CATALOG_DATABASE_NAME}\`.\`${SCHEMA_GATE_TABLE}_hidden\` TO \`${CATALOG_DATABASE_NAME}\`.\`${SCHEMA_GATE_TABLE}\``);
+    }
+  }, 60000);
+});

--- a/frontend/tests/integration/setup/schema-quarantine-mock.ts
+++ b/frontend/tests/integration/setup/schema-quarantine-mock.ts
@@ -1,0 +1,28 @@
+/**
+ * Default `@/lib/schema-quarantine` mock for the integration run.
+ *
+ * Every site-scoped route passes through `withRouteAuthz` or
+ * `validateContextualValues`, both of which now consult
+ * `catalog.schema_contract_gate` on each request (see #429). The route
+ * integration suites stub ConnectionManager with a QUEUE of `executeQuery`
+ * responses, so a real lookup would consume the first queued row and shift
+ * every later assertion — a test failure that says nothing about the route.
+ *
+ * Default here is "no schema is quarantined". A suite that needs the
+ * enforcement path overrides `findSchemaQuarantine` itself; the CLI side is
+ * proven against real MySQL in schema-gate-quarantine.integration.test.ts, and
+ * the chokepoint behavior in lib/route-authz.test.ts and
+ * lib/contextvalidation.test.ts.
+ *
+ * Mirrors the unit-side default in tests/mocks/db-mocks.ts.
+ */
+
+import { vi } from 'vitest';
+
+vi.mock('@/lib/schema-quarantine', async origImport => {
+  const actual = await origImport<typeof import('@/lib/schema-quarantine')>();
+  return {
+    ...actual,
+    findSchemaQuarantine: vi.fn(async () => null)
+  };
+});

--- a/frontend/tests/mocks/db-mocks.ts
+++ b/frontend/tests/mocks/db-mocks.ts
@@ -159,6 +159,22 @@ vi.mock('@/lib/db/poolmonitorsingleton', () => ({
   }
 }));
 
+// -------------------------------------------------------------------
+// Site-scoped route wrappers consult catalog.schema_contract_gate on
+// every request (lib/schema-quarantine.ts). Route suites drive the
+// in-memory connection with a QUEUE of responses, so a real lookup
+// would consume one of their queued rows. Default to "not quarantined";
+// a suite that needs the quarantine path overrides findSchemaQuarantine.
+// lib/schema-quarantine.test.ts un-mocks this to test the real module.
+// -------------------------------------------------------------------
+vi.mock('@/lib/schema-quarantine', async origImport => {
+  const actual = await origImport<typeof import('@/lib/schema-quarantine')>();
+  return {
+    ...actual,
+    findSchemaQuarantine: vi.fn(async () => null)
+  };
+});
+
 // ----------------------------------------
 // Optional: mock mysql2/promise createPool
 // (not strictly needed since PoolMonitor is mocked,

--- a/frontend/tests/setup/local-db-setup.ts
+++ b/frontend/tests/setup/local-db-setup.ts
@@ -418,14 +418,12 @@ export async function loadStoredProcedures(connection: mysql.Connection): Promis
       const trimmed = statement.trim();
       if (!trimmed || trimmed.length < 10) continue;
 
-      // Remove the definer clause (azureroot won't exist locally)
-      let cleaned = trimmed.replace(/definer\s*=\s*`?[^`\s]+`?@`?[^`\s]+`?\s*/gi, '');
-
-      // Check if it's a DROP statement (these should succeed)
-      const isDrop = cleaned.toLowerCase().startsWith('drop');
+      // Executed verbatim: storedprocedures.sql must not need per-environment
+      // rewriting (tests/ddl-environment-neutrality.test.ts guards that).
+      const isDrop = trimmed.toLowerCase().startsWith('drop');
 
       try {
-        await connection.query(cleaned);
+        await connection.query(trimmed);
         if (isDrop) {
           dropCount++;
         } else {
@@ -436,7 +434,7 @@ export async function loadStoredProcedures(connection: mysql.Connection): Promis
         const isExpectedError = err.message.includes('already exists') || err.message.includes('does not exist');
 
         if (!isExpectedError) {
-          const preview = cleaned.substring(0, 60).replace(/\n/g, ' ');
+          const preview = trimmed.substring(0, 60).replace(/\n/g, ' ');
           criticalErrors.push({ error: err.message.substring(0, 80), sql: preview });
         }
       }

--- a/frontend/vitest.integration.config.mts
+++ b/frontend/vitest.integration.config.mts
@@ -23,6 +23,11 @@ export default defineConfig({
     // must run in Node — not jsdom — because the route uses Node-only modules)
     include: ['tests/integration/**/*.test.ts', 'lib/provisioning/**/*.test.ts', 'lib/ctfs-export/**/*.test.ts', 'app/api/admin/provision/**/*.test.ts'],
 
+    // Route suites queue ConnectionManager responses; the per-request schema
+    // quarantine lookup would consume one. See the file's comment for why the
+    // default is "nothing quarantined" and where the real behavior is proven.
+    setupFiles: ['tests/integration/setup/schema-quarantine-mock.ts'],
+
     // SAFETY: ConnectionManager connects via getPoolMonitorInstance(), whose
     // sqlConfig.host = process.env.AZURE_SQL_SERVER — which points at PRODUCTION
     // Azure MySQL by default. Force it to the local docker container for ALL


### PR DESCRIPTION
Contains #429 (a newly provisioned site that fails the deploy contract gate takes the whole pipeline down) and closes out #399 (the `azureroot` DEFINER landmine).

## Quarantine (#429)

A new `catalog.schema_contract_gate` table records one row per site schema. `apply-schema-migrations.ts --all-sites --apply` now decides per schema:

- **passed** — migrations applied, contract audit clean. `LastPassedAt` set, any quarantine cleared.
- **quarantined** — the schema has **never** passed and failed this run. The loop continues, so every other schema still deploys. The procedure and taxonomy-view sweeps skip it, and site-scoped API requests for it return `503 SCHEMA_QUARANTINED`.
- **BLOCKED** — the schema passed before and fails now, so this deploy regressed it. The job aborts exactly as it does today.

If no schema passes, the run fails regardless — a bad migration must never ship as N quarantines. Release is automatic on the next passing apply; `QuarantinedAt` is never edited by hand.

App-side refusal lives at the two chokepoints every site-scoped request already passes through (`withRouteAuthz`, `validateContextualValues`), behind a 60s-cached lookup. Quarantine is checked **after** the access check, so an out-of-scope caller still gets a 403 and learns nothing, and admins are not exempt. A gate-read failure fails closed with `503 SCHEMA_GATE_UNAVAILABLE`.

Both deploy workflows write a result file and open (or comment on) a `schema-quarantine`-labelled issue, `continue-on-error: true` so reporting can never block the deploy it reports on.

## Definer close-out (#399)

The core fix (`807ed084`) is already on dev and main. Removed the now-dead `DEFINER =` strip in `tests/setup/local-db-setup.ts` so every integration suite executes `storedprocedures.sql` verbatim, and added `tests/ddl-environment-neutrality.test.ts` — it reads every SQL file provisioning or deploy actually executes (three base files, every manifest and catalog migration, both taxonomy views) and fails on `DEFINER =` or `azureroot`, with a case proving the checker itself catches an injected definer. Registered in `test:unit:ci`. Legacy migration 16 is deliberately untouched: it is hand-run, in no manifest.

## Notes for review

- **Bootstrap window (accepted).** On the first deploy after this lands, no schema has a pass on record, so a failure quarantines rather than blocks. Every live schema was green on the last deploy, so the expected outcome is all-passed. The window closes after one green run.
- **Gate table ordering.** The catalog-migration step already runs before the site gate, so no step was reordered. Until it has run on a server the site gate refuses to start and names the catalog runner — verified read-only against Azure, which correctly reported `Gate unavailable: catalog.schema_contract_gate does not exist` with zero writes.
- **The zero-passed floor applies only to `--all-sites`.** For a single `--schema` run it would just restate the one outcome the caller asked about.
- **Integration setup gained a default `findSchemaQuarantine` mock**, mirroring the existing unit-side convention in `tests/mocks/db-mocks.ts`: route suites drive ConnectionManager with a queue of responses, and a real per-request lookup would consume one.
- The runbook is a new tracked file, `docs/schema-contract-gate-quarantine.md`. `frontend/docs/deployment-to-development.md` is untracked (`frontend/.gitignore`'s `[A-Z][A-Z_]*.md` matches it case-insensitively on macOS) and is stale end-to-end, so it was deliberately left alone.
- The `schema-quarantine` label does not exist yet; GitHub creates it implicitly on first issue creation, but it may be worth creating deliberately with a chosen colour.

Closes #429
Closes #399
